### PR TITLE
Relax azurerm provider constraint

### DIFF
--- a/infra/azure/terraform/providers.tf
+++ b/infra/azure/terraform/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.120"
+      version = ">= 3.0.0, < 4.0.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
## Summary
- relax the AzureRM provider version constraint so Terraform can resolve existing releases

## Testing
- `terraform -chdir=infra/azure/terraform init -input=false` *(fails with 403 Forbidden from registry.terraform.io in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c94f85f12c832ba965199b0d5c064d