### PR TITLE
Ensure Argo CD bootstraps iam apps after operators are ready

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -148,12 +148,6 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.3.4/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
           kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.3.4/kubernetes/kubernetes.yml
 
-      - name: Deploy Keycloak (binds to CNPG)
-        run: |
-          kubectl apply -f k8s/apps/keycloak/keycloak.yaml
-          kubectl -n ${{ inputs.NAMESPACE_IAM }} rollout status deploy/rws-keycloak --timeout=600s || true
-
-
       - name: Prepare midPoint config and admin secret
         env:
           MIDPOINT_ADMIN_PASSWORD: ${{ secrets.MIDPOINT_ADMIN_PASSWORD }}
@@ -164,13 +158,30 @@ jobs:
           kubectl -n ${{ inputs.NAMESPACE_IAM }} create configmap midpoint-config \
             --from-file=config.xml=k8s/apps/midpoint/config.xml \
             --dry-run=client -o yaml | kubectl apply -f -
-      - name: Deploy midPoint (binds to CNPG)
-        env:
-          MIDPOINT_ADMIN_PASSWORD: ${{ secrets.MIDPOINT_ADMIN_PASSWORD }}
+
+      - name: Wait for Keycloak operator CRDs
         run: |
-          kubectl apply -f k8s/apps/midpoint/deployment.yaml
-          kubectl -n ${{ inputs.NAMESPACE_IAM }} set env deploy/midpoint MIDPOINT_ADMIN_PASSWORD="$MIDPOINT_ADMIN_PASSWORD" --containers=midpoint || true
-          kubectl -n ${{ inputs.NAMESPACE_IAM }} rollout status deploy/midpoint --timeout=600s || true
+          echo "Waiting for Keycloak CRDs to become available..."
+          for crd in keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org; do
+            kubectl wait --for=condition=Established crd/${crd} --timeout=300s
+          done
+          for ns in keycloak-system keycloak default; do
+            if kubectl -n "$ns" get deployment keycloak-operator >/dev/null 2>&1; then
+              kubectl -n "$ns" wait --for=condition=Available deployment/keycloak-operator --timeout=300s || true
+              break
+            fi
+          done
+
+      - name: Create Argo CD application for iam apps (Keycloak + midPoint)
+        run: |
+          export REPO_OWNER="${GITHUB_REPOSITORY%%/*}"
+          export REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          envsubst < k8s/argocd/apps.yaml | kubectl apply -f -
+
+      - name: Wait for iam apps Argo CD application
+        run: |
+          kubectl -n argocd wait --for=condition=Synced applications/apps --timeout=600s
+          kubectl -n argocd wait --for=condition=Healthy applications/apps --timeout=600s || true
 
       - name: Show ingress endpoints (if available)
         run: |

--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cnpg/cluster.yaml
   - keycloak/keycloak.yaml
   - midpoint/deployment.yaml

--- a/k8s/argocd/apps.yaml
+++ b/k8s/argocd/apps.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: addons
+  name: apps
   namespace: argocd
 spec:
   project: default
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/${REPO_OWNER}/${REPO_NAME}
     targetRevision: HEAD
-    path: k8s/addons
+    path: k8s/apps
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- separate the addons bootstrap from the iam application Argo CD definition
- wait for the Keycloak CRDs to register before creating the iam apps Argo CD application
- rely on Argo CD to deploy Keycloak and midPoint while keeping the CNPG cluster manual patching

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c98177d25c832b85a42f5028cc981f