### PR TITLE
Improve CNPG webhook readiness checks in bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -143,27 +143,71 @@ jobs:
           exit 1
 
       - name: Wait for CNPG webhook service endpoints
+        shell: bash
         run: |
+          set -euo pipefail
+
+          WEBHOOK_READY_FROM_ENDPOINTS=""
+          WEBHOOK_NOT_READY_FROM_ENDPOINTS=""
+          WEBHOOK_READY_FROM_SLICES=""
+          WEBHOOK_NOT_READY_FROM_SLICES=""
+
+          collect_webhook_status() {
+            WEBHOOK_READY_FROM_ENDPOINTS=""
+            WEBHOOK_NOT_READY_FROM_ENDPOINTS=""
+            WEBHOOK_READY_FROM_SLICES=""
+            WEBHOOK_NOT_READY_FROM_SLICES=""
+
+            if endpoints_json=$(kubectl -n cnpg-system get endpoints cnpg-webhook-service -o json 2>/dev/null); then
+              WEBHOOK_READY_FROM_ENDPOINTS=$(jq -r '[.subsets[]? | .addresses[]? | .ip] | join(" ")' <<<"${endpoints_json}" 2>/dev/null || true)
+              WEBHOOK_NOT_READY_FROM_ENDPOINTS=$(jq -r '[.subsets[]? | .notReadyAddresses[]? | .ip] | join(" ")' <<<"${endpoints_json}" 2>/dev/null || true)
+            fi
+
+            if endpointslices_json=$(kubectl -n cnpg-system get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=cnpg-webhook-service -o json 2>/dev/null); then
+              WEBHOOK_READY_FROM_SLICES=$(jq -r '[.items[]? | .endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | join(" ")' <<<"${endpointslices_json}" 2>/dev/null || true)
+              WEBHOOK_NOT_READY_FROM_SLICES=$(jq -r '[.items[]? | .endpoints[]? | select(.conditions.ready != true) | .addresses[]?] | join(" ")' <<<"${endpointslices_json}" 2>/dev/null || true)
+            fi
+          }
+
+          log_webhook_status() {
+            echo "cnpg-webhook-service ready IPs (Endpoints): ${WEBHOOK_READY_FROM_ENDPOINTS:-<none>}"
+            echo "cnpg-webhook-service notReady IPs (Endpoints): ${WEBHOOK_NOT_READY_FROM_ENDPOINTS:-<none>}"
+            echo "cnpg-webhook-service ready IPs (EndpointSlices): ${WEBHOOK_READY_FROM_SLICES:-<none>}"
+            echo "cnpg-webhook-service notReady IPs (EndpointSlices): ${WEBHOOK_NOT_READY_FROM_SLICES:-<none>}"
+          }
+
           echo "Ensuring cnpg-webhook-service has ready endpoints..."
-          for attempt in $(seq 1 30); do
-            if kubectl -n cnpg-system get endpoints cnpg-webhook-service >/dev/null 2>&1; then
-              ready_endpoints=$(kubectl -n cnpg-system get endpoints cnpg-webhook-service -o jsonpath='{range .subsets[*].addresses[*]}{.ip} {end}' 2>/dev/null)
-              if [ -n "${ready_endpoints}" ]; then
-                echo "cnpg-webhook-service has ready endpoints: ${ready_endpoints}"
-                echo "Waiting a few seconds to let the Kubernetes API server register the webhook endpoints"
-                sleep 10
-                exit 0
-              fi
-              not_ready_endpoints=$(kubectl -n cnpg-system get endpoints cnpg-webhook-service -o jsonpath='{range .subsets[*].notReadyAddresses[*]}{.ip} {end}' 2>/dev/null)
-              echo "cnpg-webhook-service found but endpoints are not ready yet (attempt ${attempt}/30). NotReady: ${not_ready_endpoints:-none}"
+          consecutive_ready=0
+          for attempt in $(seq 1 45); do
+            if ! kubectl -n cnpg-system get service cnpg-webhook-service >/dev/null 2>&1; then
+              echo "cnpg-webhook-service not created yet (attempt ${attempt}/45)"
+              consecutive_ready=0
             else
-              echo "cnpg-webhook-service not created yet (attempt ${attempt}/30)"
+              collect_webhook_status
+              log_webhook_status
+              if [ -n "${WEBHOOK_READY_FROM_ENDPOINTS}" ] || [ -n "${WEBHOOK_READY_FROM_SLICES}" ]; then
+                consecutive_ready=$((consecutive_ready + 1))
+                echo "Ready endpoints observed (${consecutive_ready}/3 consecutive confirmations)"
+                if [ "${consecutive_ready}" -ge 3 ]; then
+                  echo "cnpg-webhook-service has ready endpoints that appear stable"
+                  echo "Waiting a few seconds to let the Kubernetes API server register the webhook endpoints"
+                  sleep 10
+                  exit 0
+                fi
+                sleep 5
+                continue
+              fi
+
+              echo "cnpg-webhook-service endpoints not ready yet (attempt ${attempt}/45)"
+              consecutive_ready=0
             fi
             sleep 10
           done
+
           echo "Timed out waiting for cnpg-webhook-service endpoints"
-          kubectl -n cnpg-system get pods -l app.kubernetes.io/instance=cnpg -o wide || true
+          kubectl -n cnpg-system get pods -l app.kubernetes.io/name=cloudnative-pg -o wide || true
           kubectl -n cnpg-system get endpoints cnpg-webhook-service -o yaml || true
+          kubectl -n cnpg-system get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=cnpg-webhook-service -o yaml || true
           exit 1
 
       - name: Create CNPG secrets (DB users + superuser)
@@ -254,14 +298,47 @@ jobs:
             exit 1
           fi
 
-          ready_endpoints=$(kubectl -n cnpg-system get endpoints cnpg-webhook-service -o jsonpath='{range .subsets[*].addresses[*]}{.ip} {end}' 2>/dev/null || true)
-          if [ -z "${ready_endpoints}" ]; then
+          WEBHOOK_READY_FROM_ENDPOINTS=""
+          WEBHOOK_NOT_READY_FROM_ENDPOINTS=""
+          WEBHOOK_READY_FROM_SLICES=""
+          WEBHOOK_NOT_READY_FROM_SLICES=""
+
+          collect_webhook_status() {
+            WEBHOOK_READY_FROM_ENDPOINTS=""
+            WEBHOOK_NOT_READY_FROM_ENDPOINTS=""
+            WEBHOOK_READY_FROM_SLICES=""
+            WEBHOOK_NOT_READY_FROM_SLICES=""
+
+            if endpoints_json=$(kubectl -n cnpg-system get endpoints cnpg-webhook-service -o json 2>/dev/null); then
+              WEBHOOK_READY_FROM_ENDPOINTS=$(jq -r '[.subsets[]? | .addresses[]? | .ip] | join(" ")' <<<"${endpoints_json}" 2>/dev/null || true)
+              WEBHOOK_NOT_READY_FROM_ENDPOINTS=$(jq -r '[.subsets[]? | .notReadyAddresses[]? | .ip] | join(" ")' <<<"${endpoints_json}" 2>/dev/null || true)
+            fi
+
+            if endpointslices_json=$(kubectl -n cnpg-system get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=cnpg-webhook-service -o json 2>/dev/null); then
+              WEBHOOK_READY_FROM_SLICES=$(jq -r '[.items[]? | .endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | join(" ")' <<<"${endpointslices_json}" 2>/dev/null || true)
+              WEBHOOK_NOT_READY_FROM_SLICES=$(jq -r '[.items[]? | .endpoints[]? | select(.conditions.ready != true) | .addresses[]?] | join(" ")' <<<"${endpointslices_json}" 2>/dev/null || true)
+            fi
+          }
+
+          log_webhook_status() {
+            echo "cnpg-webhook-service ready IPs (Endpoints): ${WEBHOOK_READY_FROM_ENDPOINTS:-<none>}"
+            echo "cnpg-webhook-service notReady IPs (Endpoints): ${WEBHOOK_NOT_READY_FROM_ENDPOINTS:-<none>}"
+            echo "cnpg-webhook-service ready IPs (EndpointSlices): ${WEBHOOK_READY_FROM_SLICES:-<none>}"
+            echo "cnpg-webhook-service notReady IPs (EndpointSlices): ${WEBHOOK_NOT_READY_FROM_SLICES:-<none>}"
+          }
+
+          collect_webhook_status
+          log_webhook_status
+          if [ -z "${WEBHOOK_READY_FROM_ENDPOINTS}" ] && [ -z "${WEBHOOK_READY_FROM_SLICES}" ]; then
             echo "ERROR: cnpg-webhook-service currently has no ready endpoints"
             kubectl -n cnpg-system get endpoints cnpg-webhook-service -o yaml || true
+            kubectl -n cnpg-system get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=cnpg-webhook-service -o yaml || true
             exit 1
           fi
 
-          echo "cnpg-webhook-service ready endpoints: ${ready_endpoints}"
+          ready_endpoints="${WEBHOOK_READY_FROM_ENDPOINTS:-${WEBHOOK_READY_FROM_SLICES}}"
+
+          echo "cnpg-webhook-service ready endpoints: ${ready_endpoints:-<unknown>}"
 
       - name: Apply CNPG cluster (iam-db)
         env:
@@ -274,6 +351,49 @@ jobs:
           manifest="$(mktemp)"
           trap 'rm -f "${manifest}"' EXIT
           sed "s/{{STORAGE_ACCOUNT}}/${STORAGE_ACCOUNT}/g" k8s/apps/cnpg/cluster.yaml > "${manifest}"
+
+          WEBHOOK_READY_FROM_ENDPOINTS=""
+          WEBHOOK_NOT_READY_FROM_ENDPOINTS=""
+          WEBHOOK_READY_FROM_SLICES=""
+          WEBHOOK_NOT_READY_FROM_SLICES=""
+
+          collect_webhook_status() {
+            WEBHOOK_READY_FROM_ENDPOINTS=""
+            WEBHOOK_NOT_READY_FROM_ENDPOINTS=""
+            WEBHOOK_READY_FROM_SLICES=""
+            WEBHOOK_NOT_READY_FROM_SLICES=""
+
+            if endpoints_json=$(kubectl -n cnpg-system get endpoints cnpg-webhook-service -o json 2>/dev/null); then
+              WEBHOOK_READY_FROM_ENDPOINTS=$(jq -r '[.subsets[]? | .addresses[]? | .ip] | join(" ")' <<<"${endpoints_json}" 2>/dev/null || true)
+              WEBHOOK_NOT_READY_FROM_ENDPOINTS=$(jq -r '[.subsets[]? | .notReadyAddresses[]? | .ip] | join(" ")' <<<"${endpoints_json}" 2>/dev/null || true)
+            fi
+
+            if endpointslices_json=$(kubectl -n cnpg-system get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=cnpg-webhook-service -o json 2>/dev/null); then
+              WEBHOOK_READY_FROM_SLICES=$(jq -r '[.items[]? | .endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | join(" ")' <<<"${endpointslices_json}" 2>/dev/null || true)
+              WEBHOOK_NOT_READY_FROM_SLICES=$(jq -r '[.items[]? | .endpoints[]? | select(.conditions.ready != true) | .addresses[]?] | join(" ")' <<<"${endpointslices_json}" 2>/dev/null || true)
+            fi
+          }
+
+          log_webhook_status() {
+            echo "cnpg-webhook-service ready IPs (Endpoints): ${WEBHOOK_READY_FROM_ENDPOINTS:-<none>}"
+            echo "cnpg-webhook-service notReady IPs (Endpoints): ${WEBHOOK_NOT_READY_FROM_ENDPOINTS:-<none>}"
+            echo "cnpg-webhook-service ready IPs (EndpointSlices): ${WEBHOOK_READY_FROM_SLICES:-<none>}"
+            echo "cnpg-webhook-service notReady IPs (EndpointSlices): ${WEBHOOK_NOT_READY_FROM_SLICES:-<none>}"
+          }
+
+          is_webhook_unavailable_error() {
+            local message="$1"
+            if grep -qi 'no endpoints available for service "cnpg-webhook-service"' <<<"${message}"; then
+              return 0
+            fi
+            if grep -qi 'failed calling webhook "mcluster.cnpg.io"' <<<"${message}" && grep -qi 'cnpg-webhook-service' <<<"${message}"; then
+              return 0
+            fi
+            if grep -qi 'failed calling webhook' <<<"${message}" && grep -qi 'cnpg-webhook-service' <<<"${message}"; then
+              return 0
+            fi
+            return 1
+          }
 
           max_attempts=8
           success=0
@@ -291,13 +411,11 @@ jobs:
               prereqs_ready=0
             fi
 
-            ready_endpoints=$(kubectl -n cnpg-system get endpoints cnpg-webhook-service -o jsonpath='{range .subsets[*].addresses[*]}{.ip} {end}' 2>/dev/null || true)
-            if [ -z "${ready_endpoints}" ]; then
+            collect_webhook_status
+            log_webhook_status
+            if [ -z "${WEBHOOK_READY_FROM_ENDPOINTS}" ] && [ -z "${WEBHOOK_READY_FROM_SLICES}" ]; then
               echo "cnpg-webhook-service has no ready endpoints before attempt ${attempt}"
-              kubectl -n cnpg-system get endpoints cnpg-webhook-service -o yaml || true
               prereqs_ready=0
-            else
-              echo "cnpg-webhook-service endpoints: ${ready_endpoints}"
             fi
 
             if [ "${prereqs_ready}" -ne 1 ]; then
@@ -307,24 +425,50 @@ jobs:
             fi
 
             echo "Running server-side dry run to verify CNPG webhooks are reachable"
-            if ! kubectl apply --dry-run=server -f "${manifest}"; then
-              echo "Server-side dry run failed on attempt ${attempt}; CNPG webhooks may still be unavailable"
-              kubectl -n cnpg-system get endpoints cnpg-webhook-service -o wide || true
+            if dry_run_output=$(kubectl apply --dry-run=server -f "${manifest}" 2>&1); then
+              echo "${dry_run_output}"
+            else
+              echo "${dry_run_output}"
+              if is_webhook_unavailable_error "${dry_run_output}"; then
+                echo "Server-side dry run indicates CNPG webhooks are unavailable; retrying after delay"
+                sleep 20
+                continue
+              fi
+              echo "Server-side dry run failed for an unexpected reason; showing diagnostics"
               kubectl -n cnpg-system get pods -l app.kubernetes.io/name=cloudnative-pg -o wide || true
+              kubectl -n cnpg-system describe deployment cnpg-cloudnative-pg || true
+              kubectl -n cnpg-system get endpoints cnpg-webhook-service -o yaml || true
+              kubectl -n cnpg-system get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=cnpg-webhook-service -o yaml || true
               sleep 20
               continue
             fi
 
-            if kubectl apply -f "${manifest}"; then
+            collect_webhook_status
+            log_webhook_status
+            if [ -z "${WEBHOOK_READY_FROM_ENDPOINTS}" ] && [ -z "${WEBHOOK_READY_FROM_SLICES}" ]; then
+              echo "cnpg-webhook-service endpoints disappeared after dry run; waiting before retry"
+              sleep 20
+              continue
+            fi
+
+            if apply_output=$(kubectl apply -f "${manifest}" 2>&1); then
+              echo "${apply_output}"
               echo "CNPG cluster manifest applied successfully"
               success=1
               break
+            else
+              echo "${apply_output}"
+              if is_webhook_unavailable_error "${apply_output}"; then
+                echo "kubectl apply failed because CNPG webhooks were unavailable; retrying after gathering diagnostics"
+              else
+                echo "kubectl apply failed on attempt ${attempt}; showing CNPG operator diagnostics"
+              fi
             fi
 
-            echo "kubectl apply failed on attempt ${attempt}; showing CNPG operator diagnostics"
             kubectl -n cnpg-system get pods -l app.kubernetes.io/name=cloudnative-pg -o wide || true
             kubectl -n cnpg-system describe deployment cnpg-cloudnative-pg || true
             kubectl -n cnpg-system get endpoints cnpg-webhook-service -o yaml || true
+            kubectl -n cnpg-system get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=cnpg-webhook-service -o yaml || true
             sleep 20
           done
 


### PR DESCRIPTION
## Summary
- add endpoint slice awareness and consecutive readiness checks before applying the CNPG cluster
- validate CNPG prerequisites using the same endpoint slice aware logic for webhook readiness
- retry CNPG cluster creation when the webhook is temporarily unavailable and surface richer diagnostics

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68c9a34333b0832baab57a0a3373aac0