### PR TITLE
Enable server-side apply for CNPG operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Fetch AKS kubeconfig (OIDC auth)
    - Install **Argo CD**
    - Sync **addons** via Argo: Ingress-NGINX, cert-manager, CNPG Operator
+     - The CNPG Argo CD application enables **Server Side Apply** so the large CRDs can be created without
+       hitting the Kubernetes annotation size limit. Ensure your Argo CD version supports the
+       `ServerSideApply` sync option (v2.5+).
    - Create **CNPG** cluster `iam-db` (+ Azure Blob backup config)
    - Install **Keycloak Operator** then create a **Keycloak** CR bound to CNPG
    - Deploy **midPoint** bound to CNPG

--- a/k8s/addons/cnpg-operator/application.yaml
+++ b/k8s/addons/cnpg-operator/application.yaml
@@ -20,3 +20,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary
- enable server-side apply on the CloudNativePG Argo CD application so large CRDs can be synced without hitting annotation limits
- document the server-side apply requirement for the bootstrap workflow in the README

## Testing
- not run (configuration-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68c9b0a57744832b9578af62f73decc7