### PR TITLE
Ensure Argo CD can authenticate to the GitHub repository

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -65,6 +65,50 @@ jobs:
           echo "Waiting for Argo CD application controller statefulset"
           kubectl -n argocd rollout status statefulset/argocd-application-controller --timeout=300s
 
+      - name: Configure Argo CD repository credentials
+        shell: bash
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ARGOCD_REPO_USERNAME: ${{ secrets.ARGOCD_REPO_USERNAME }}
+          ARGOCD_REPO_TOKEN: ${{ secrets.ARGOCD_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          REPO_OWNER="${GITHUB_REPOSITORY%%/*}"
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          if [ -z "${ARGOCD_REPO_USERNAME}" ] || [ -z "${ARGOCD_REPO_TOKEN}" ]; then
+            echo "Secrets ARGOCD_REPO_USERNAME and ARGOCD_REPO_TOKEN not provided; checking if repository is public..."
+            if curl -sS "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}" | jq -e '.private == false' >/dev/null; then
+              echo "Repository is public; skipping Argo CD repository secret."
+              exit 0
+            fi
+            echo "Repository appears to be private. Provide ARGOCD_REPO_USERNAME and ARGOCD_REPO_TOKEN secrets so Argo CD can sync."
+            exit 1
+          fi
+
+          sanitized=$(printf '%s' "${REPO_OWNER}-${REPO_NAME}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/^-*//;s/-*$//')
+          if [ -z "${sanitized}" ]; then
+            sanitized="repo"
+          fi
+          SECRET_NAME="repo-${sanitized}"
+
+          kubectl apply -f - <<EOF
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ${SECRET_NAME}
+            namespace: argocd
+            labels:
+              argocd.argoproj.io/secret-type: repository
+          type: Opaque
+          stringData:
+            url: https://github.com/${REPO_OWNER}/${REPO_NAME}
+            username: ${ARGOCD_REPO_USERNAME}
+            password: ${ARGOCD_REPO_TOKEN}
+EOF
+
+          echo "Configured Argo CD repository credentials in secret ${SECRET_NAME}"
+
       - name: Sync addons via Argo (Ingress-NGINX, cert-manager, CNPG operator)
         run: |
           export REPO_OWNER="${GITHUB_REPOSITORY%%/*}"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - `AZURE_TENANT_ID` – your Entra tenant ID
   - `AZURE_SUBSCRIPTION_ID` – your subscription ID
   - `AZURE_CLIENT_ID` – the app registration **client ID** created for OIDC
+  - `ARGOCD_REPO_USERNAME` – GitHub username that owns a Personal Access Token for Argo CD
+  - `ARGOCD_REPO_TOKEN` – GitHub Personal Access Token (Classic) with **repo** scope so Argo CD can clone this repo
   - (Optional) `LOCATION` – default `westeurope`
   - (Optional) `RESOURCE_PREFIX` – short prefix, default `rwsdemo`
   - **DB secrets** (you can change later):
@@ -27,6 +29,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - **midPoint admin**: `MIDPOINT_ADMIN_PASSWORD` – initial `administrator` password
 
 > **Tip**: For the first run, keep short, simple passwords; rotate afterwards.
+
+> **Argo CD access**: Provide the repository username/token secrets above whenever the repo is private. Without them the
+> bootstrap workflow cannot register the repo with Argo CD, so it will never sync the Kubernetes applications.
 
 ---
 


### PR DESCRIPTION
## Summary
- add bootstrap step that configures an Argo CD repository secret using PAT credentials and refuse to continue when private repos lack them
- document the required ARGOCD_REPO_USERNAME and ARGOCD_REPO_TOKEN secrets in the setup guide

## Testing
- not run (workflow changes only)

------
https://chatgpt.com/codex/tasks/task_e_68c9b873e288832b94a8d3a6685fd7ad