### PR TITLE
Fix YAML syntax for ArgoCD bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -92,20 +92,15 @@ jobs:
           fi
           SECRET_NAME="repo-${sanitized}"
 
-          kubectl apply -f - <<EOF
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            name: ${SECRET_NAME}
-            namespace: argocd
-            labels:
-              argocd.argoproj.io/secret-type: repository
-          type: Opaque
-          stringData:
-            url: https://github.com/${REPO_OWNER}/${REPO_NAME}
-            username: ${ARGOCD_REPO_USERNAME}
-            password: ${ARGOCD_REPO_TOKEN}
-EOF
+          kubectl -n argocd create secret generic "${SECRET_NAME}" \
+            --type=Opaque \
+            --from-literal=url="https://github.com/${REPO_OWNER}/${REPO_NAME}" \
+            --from-literal=username="${ARGOCD_REPO_USERNAME}" \
+            --from-literal=password="${ARGOCD_REPO_TOKEN}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          kubectl -n argocd label secret "${SECRET_NAME}" \
+            argocd.argoproj.io/secret-type=repository --overwrite
 
           echo "Configured Argo CD repository credentials in secret ${SECRET_NAME}"
 


### PR DESCRIPTION
## Summary
- replace the heredoc secret manifest with `kubectl create secret` plus labeling so the workflow keeps the Argo CD repo secret
- avoid using a top-level EOF token that broke YAML parsing of the workflow file

## Testing
- python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/02_bootstrap_argocd.yml'))"

------
https://chatgpt.com/codex/tasks/task_e_68c9bb1ba78c832baf3ceb6ffab1148a