### PR TITLE
Fix CNPG operator sync failure by pre-installing CRDs

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -106,6 +106,52 @@ jobs:
             argocd.argoproj.io/secret-type=repository --overwrite
           echo "Configured Argo CD repository credentials in secret ${SECRET_NAME}"
 
+      - name: Pre-install CloudNativePG CRDs (server-side apply)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! command -v helm >/dev/null 2>&1; then
+            echo "Helm not found on runner; installing Helm 3"
+            curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          fi
+
+          echo "Adding CloudNativePG Helm repository"
+          helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts --force-update >/dev/null 2>&1 || true
+
+          echo "Updating CloudNativePG Helm repository index"
+          for attempt in $(seq 1 5); do
+            if helm repo update cloudnative-pg >/dev/null 2>&1; then
+              echo "Helm repository index refreshed"
+              break
+            fi
+            if [ "${attempt}" -eq 5 ]; then
+              echo "Failed to update CloudNativePG Helm repository after ${attempt} attempts"
+              exit 1
+            fi
+            echo "Helm repo update failed (attempt ${attempt}/5); retrying in 5 seconds"
+            sleep 5
+          done
+
+          echo "Rendering CloudNativePG CRDs for version 0.22.1"
+          helm show crds cloudnative-pg/cloudnative-pg --version 0.22.1 > /tmp/cloudnative-pg-crds.yaml
+
+          echo "Applying CloudNativePG CRDs with server-side apply"
+          kubectl apply --server-side -f /tmp/cloudnative-pg-crds.yaml
+
+          echo "Removing potential last-applied annotations that exceed Kubernetes limits"
+          for crd in \
+            backups.postgresql.cnpg.io \
+            clusterimagecatalogs.postgresql.cnpg.io \
+            clusters.postgresql.cnpg.io \
+            imagecatalogs.postgresql.cnpg.io \
+            poolers.postgresql.cnpg.io \
+            scheduledbackups.postgresql.cnpg.io; do
+            if kubectl get crd "${crd}" >/dev/null 2>&1; then
+              kubectl annotate crd "${crd}" kubectl.kubernetes.io/last-applied-configuration- >/dev/null 2>&1 || true
+            fi
+          done
+
       - name: Sync addons via Argo (Ingress-NGINX, cert-manager, CNPG operator)
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Fetch AKS kubeconfig (OIDC auth)
    - Install **Argo CD**
    - Sync **addons** via Argo: Ingress-NGINX, cert-manager, CNPG Operator
-     - The CNPG Argo CD application enables **Server Side Apply** so the large CRDs can be created without
-       hitting the Kubernetes annotation size limit. Ensure your Argo CD version supports the
-       `ServerSideApply` sync option (v2.5+).
+     - The workflow pre-installs CloudNativePG CRDs with `kubectl apply --server-side` (rendered via `helm show crds`) so
+       the large schemas bypass the Kubernetes annotation size limit, and the Argo CD application skips managing CRDs to avoid
+       reintroducing the oversized annotation.
    - Create **CNPG** cluster `iam-db` (+ Azure Blob backup config)
    - Install **Keycloak Operator** then create a **Keycloak** CR bound to CNPG
    - Deploy **midPoint** bound to CNPG

--- a/k8s/addons/cnpg-operator/application.yaml
+++ b/k8s/addons/cnpg-operator/application.yaml
@@ -14,6 +14,7 @@ spec:
     targetRevision: 0.22.1
     helm:
       releaseName: cnpg
+      skipCrds: true
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- ensure the bootstrap workflow renders CloudNativePG CRDs with Helm and applies them with server-side apply before Argo CD syncs addons
- stop the Argo CD cnpg-operator application from reapplying CRDs so it only manages the controller resources
- document the new CNPG CRD bootstrap behavior in the README

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca762db844832ba9d44fd6be606ea6