### PR TITLE
Disable Argo CD from managing CNPG CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Install **Argo CD**
    - Sync **addons** via Argo: Ingress-NGINX, cert-manager, CNPG Operator
      - The workflow pre-installs CloudNativePG CRDs with `kubectl apply --server-side` (rendered via `helm show crds`) so
-       the large schemas bypass the Kubernetes annotation size limit, and the Argo CD application skips managing CRDs to avoid
+       the large schemas bypass the Kubernetes annotation size limit, and the Argo CD application disables chart-managed CRDs (Helm value `crds.create=false`) to avoid
        reintroducing the oversized annotation.
    - Create **CNPG** cluster `iam-db` (+ Azure Blob backup config)
    - Install **Keycloak Operator** then create a **Keycloak** CR bound to CNPG

--- a/k8s/addons/cnpg-operator/application.yaml
+++ b/k8s/addons/cnpg-operator/application.yaml
@@ -15,6 +15,9 @@ spec:
     helm:
       releaseName: cnpg
       skipCrds: true
+      parameters:
+        - name: crds.create
+          value: "false"
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- configure the cnpg-operator Argo CD Application to set the Helm value `crds.create=false`, preventing the chart from re-applying CloudNativePG CRDs that Argo already pre-installs
- document in the bootstrap README that the Argo CD Application disables chart-managed CRDs to avoid the oversized annotation issue

## Testing
- not run (pipeline relies on GitHub Actions)

------
https://chatgpt.com/codex/tasks/task_e_68ca87d25ec0832bb3c6a14fd18c0367