### PR TITLE
Handle CloudNativePG chart without helm-show CRDs

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -134,7 +134,63 @@ jobs:
           done
 
           echo "Rendering CloudNativePG CRDs for version 0.22.1"
-          helm show crds cloudnative-pg/cloudnative-pg --version 0.22.1 > /tmp/cloudnative-pg-crds.yaml
+          if ! helm show crds cloudnative-pg/cloudnative-pg --version 0.22.1 > /tmp/cloudnative-pg-crds.yaml; then
+            echo "helm show crds failed; aborting"
+            exit 1
+          fi
+
+          if [ ! -s /tmp/cloudnative-pg-crds.yaml ]; then
+            echo "No CRDs were returned by 'helm show crds'; falling back to helm template rendering"
+            helm template cloudnative-pg-crds cloudnative-pg/cloudnative-pg \
+              --version 0.22.1 \
+              --include-crds \
+              --namespace cnpg-system > /tmp/cloudnative-pg-crds-rendered.yaml
+
+            python3 <<'PY'
+import pathlib
+import sys
+
+rendered_path = pathlib.Path("/tmp/cloudnative-pg-crds-rendered.yaml")
+output_path = pathlib.Path("/tmp/cloudnative-pg-crds.yaml")
+
+if not rendered_path.exists():
+    print("Rendered CRD manifest not found", file=sys.stderr)
+    sys.exit(1)
+
+docs = []
+current = []
+for line in rendered_path.read_text().splitlines():
+    if line.strip() == '---':
+        if current:
+            docs.append('\n'.join(current).strip())
+            current = []
+        continue
+    current.append(line)
+if current:
+    docs.append('\n'.join(current).strip())
+
+crd_docs = []
+for doc in docs:
+    for line in doc.splitlines():
+        stripped = line.strip()
+        if stripped.startswith('kind:'):
+            if stripped.split(':', 1)[1].strip() == 'CustomResourceDefinition':
+                crd_docs.append(doc)
+            break
+
+if not crd_docs:
+    print("No CustomResourceDefinition documents found in rendered template", file=sys.stderr)
+    sys.exit(1)
+
+output_path.write_text('---\n'.join(crd_docs) + '\n')
+PY
+          fi
+
+          if [ ! -s /tmp/cloudnative-pg-crds.yaml ]; then
+            echo "Failed to render CloudNativePG CRDs"
+            ls -l /tmp/cloudnative-pg-crds*
+            exit 1
+          fi
 
           echo "Applying CloudNativePG CRDs with server-side apply"
           kubectl apply --server-side -f /tmp/cloudnative-pg-crds.yaml

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Fetch AKS kubeconfig (OIDC auth)
    - Install **Argo CD**
    - Sync **addons** via Argo: Ingress-NGINX, cert-manager, CNPG Operator
-     - The workflow pre-installs CloudNativePG CRDs with `kubectl apply --server-side` (rendered via `helm show crds`) so
-       the large schemas bypass the Kubernetes annotation size limit, and the Argo CD application disables chart-managed CRDs (Helm value `crds.create=false`) to avoid
-       reintroducing the oversized annotation.
+     - The workflow pre-installs CloudNativePG CRDs with `kubectl apply --server-side`. It first attempts to render them via `helm show crds` and, if the chart does not publish CRDs in that location (as happens with recent releases), falls back to `helm template --include-crds` and filters the `CustomResourceDefinition` manifests. This keeps the large schemas out of Kubernetes' annotation history while the Argo CD application disables chart-managed CRDs (`crds.create=false`) to avoid reintroducing the oversized annotation.
    - Create **CNPG** cluster `iam-db` (+ Azure Blob backup config)
    - Install **Keycloak Operator** then create a **Keycloak** CR bound to CNPG
    - Deploy **midPoint** bound to CNPG


### PR DESCRIPTION
## Summary
- add a fallback in the bootstrap workflow that renders CloudNativePG CRDs with `helm template --include-crds` when `helm show crds` returns nothing, ensuring the CRDs are still applied
- document the new rendering behaviour in the README so operators know why the workflow pre-installs CRDs this way

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca8b307034832ba8812fcaaa17b593