### PR TITLE
Fix indentation for CloudNativePG fallback script

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -146,44 +146,44 @@ jobs:
               --include-crds \
               --namespace cnpg-system > /tmp/cloudnative-pg-crds-rendered.yaml
 
-            python3 <<'PY'
-import pathlib
-import sys
+            cat <<'PY' | sed 's/^            //' | python3 -
+            import pathlib
+            import sys
 
-rendered_path = pathlib.Path("/tmp/cloudnative-pg-crds-rendered.yaml")
-output_path = pathlib.Path("/tmp/cloudnative-pg-crds.yaml")
+            rendered_path = pathlib.Path("/tmp/cloudnative-pg-crds-rendered.yaml")
+            output_path = pathlib.Path("/tmp/cloudnative-pg-crds.yaml")
 
-if not rendered_path.exists():
-    print("Rendered CRD manifest not found", file=sys.stderr)
-    sys.exit(1)
+            if not rendered_path.exists():
+                print("Rendered CRD manifest not found", file=sys.stderr)
+                sys.exit(1)
 
-docs = []
-current = []
-for line in rendered_path.read_text().splitlines():
-    if line.strip() == '---':
-        if current:
-            docs.append('\n'.join(current).strip())
+            docs = []
             current = []
-        continue
-    current.append(line)
-if current:
-    docs.append('\n'.join(current).strip())
+            for line in rendered_path.read_text().splitlines():
+                if line.strip() == '---':
+                    if current:
+                        docs.append('\n'.join(current).strip())
+                        current = []
+                    continue
+                current.append(line)
+            if current:
+                docs.append('\n'.join(current).strip())
 
-crd_docs = []
-for doc in docs:
-    for line in doc.splitlines():
-        stripped = line.strip()
-        if stripped.startswith('kind:'):
-            if stripped.split(':', 1)[1].strip() == 'CustomResourceDefinition':
-                crd_docs.append(doc)
-            break
+            crd_docs = []
+            for doc in docs:
+                for line in doc.splitlines():
+                    stripped = line.strip()
+                    if stripped.startswith('kind:'):
+                        if stripped.split(':', 1)[1].strip() == 'CustomResourceDefinition':
+                            crd_docs.append(doc)
+                        break
 
-if not crd_docs:
-    print("No CustomResourceDefinition documents found in rendered template", file=sys.stderr)
-    sys.exit(1)
+            if not crd_docs:
+                print("No CustomResourceDefinition documents found in rendered template", file=sys.stderr)
+                sys.exit(1)
 
-output_path.write_text('---\n'.join(crd_docs) + '\n')
-PY
+            output_path.write_text('---\n'.join(crd_docs) + '\n')
+            PY
           fi
 
           if [ ! -s /tmp/cloudnative-pg-crds.yaml ]; then


### PR DESCRIPTION
## Summary
- fix the YAML indentation in the CloudNativePG CRD fallback block so the workflow parses correctly
- invoke the Python filtering script via a heredoc that strips the workflow indentation before piping to python3

## Testing
- ruby -ryaml -e 'YAML.load_file(".github/workflows/02_bootstrap_argocd.yml")'

------
https://chatgpt.com/codex/tasks/task_e_68ca8fb05048832b8623dcfc25f23546