### PR TITLE
Fix CloudNativePG CRD fallback heredoc indentation

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -146,44 +146,44 @@ jobs:
               --include-crds \
               --namespace cnpg-system > /tmp/cloudnative-pg-crds-rendered.yaml
 
-            python3 <<'PY'
-import pathlib
-import sys
+              python3 <<'PY'
+              import pathlib
+              import sys
 
-rendered_path = pathlib.Path("/tmp/cloudnative-pg-crds-rendered.yaml")
-output_path = pathlib.Path("/tmp/cloudnative-pg-crds.yaml")
+              rendered_path = pathlib.Path("/tmp/cloudnative-pg-crds-rendered.yaml")
+              output_path = pathlib.Path("/tmp/cloudnative-pg-crds.yaml")
 
-if not rendered_path.exists():
-    print("Rendered CRD manifest not found", file=sys.stderr)
-    sys.exit(1)
+              if not rendered_path.exists():
+                  print("Rendered CRD manifest not found", file=sys.stderr)
+                  sys.exit(1)
 
-docs = []
-current = []
-for line in rendered_path.read_text().splitlines():
-    if line.strip() == '---':
-        if current:
-            docs.append('\n'.join(current).strip())
-            current = []
-        continue
-    current.append(line)
-if current:
-    docs.append('\n'.join(current).strip())
+              docs = []
+              current = []
+              for line in rendered_path.read_text().splitlines():
+                  if line.strip() == '---':
+                      if current:
+                          docs.append('\n'.join(current).strip())
+                          current = []
+                      continue
+                  current.append(line)
+              if current:
+                  docs.append('\n'.join(current).strip())
 
-crd_docs = []
-for doc in docs:
-    for line in doc.splitlines():
-        stripped = line.strip()
-        if stripped.startswith('kind:'):
-            if stripped.split(':', 1)[1].strip() == 'CustomResourceDefinition':
-                crd_docs.append(doc)
-            break
+              crd_docs = []
+              for doc in docs:
+                  for line in doc.splitlines():
+                      stripped = line.strip()
+                      if stripped.startswith('kind:'):
+                          if stripped.split(':', 1)[1].strip() == 'CustomResourceDefinition':
+                              crd_docs.append(doc)
+                          break
 
-if not crd_docs:
-    print("No CustomResourceDefinition documents found in rendered template", file=sys.stderr)
-    sys.exit(1)
+              if not crd_docs:
+                  print("No CustomResourceDefinition documents found in rendered template", file=sys.stderr)
+                  sys.exit(1)
 
-output_path.write_text('---\n'.join(crd_docs) + '\n')
-PY
+              output_path.write_text('---\n'.join(crd_docs) + '\n')
+              PY
           fi
 
           if [ ! -s /tmp/cloudnative-pg-crds.yaml ]; then


### PR DESCRIPTION
## Summary
- fix the indentation of the fallback Python heredoc that renders CloudNativePG CRDs so the workflow YAML parses correctly

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/02_bootstrap_argocd.yml

------
https://chatgpt.com/codex/tasks/task_e_68ca8fb05048832b8623dcfc25f23546