### PR TITLE
Fix CloudNativePG CRD fallback to generate valid YAML

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -182,7 +182,12 @@ jobs:
               print("No CustomResourceDefinition documents found in rendered template", file=sys.stderr)
               sys.exit(1)
 
-          output_path.write_text('---\n'.join(crd_docs) + '\n')
+          # Ensure each CRD document is separated by a YAML document marker on its
+          # own line. Joining with "\n---\n" avoids concatenating the marker onto
+          # the last line of the previous document when that document does not end
+          # with a trailing newline (which would create invalid YAML like
+          # "metadata:...---" and trigger kubectl parsing errors).
+          output_path.write_text('\n---\n'.join(crd_docs) + '\n')
 
           PY
           fi


### PR DESCRIPTION
## Summary
- ensure the fallback CRD rendering joins manifests with newline-wrapped `---` separators so the YAML stays valid when documents lack trailing newlines
- this prevents kubectl from failing to parse the generated CRDs during the pre-install step

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca950d6c9c832b89e12edcd11ccc61