### PR TITLE
Handle Keycloak realm import drift in Argo CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 - **Terraform vars**: `infra/azure/terraform/terraform.tfvars` (or via repo variables / workflow inputs)
 - **Helm/Argo versions**: see `k8s/addons/*/application.yaml`
 - **DB sizing**: `k8s/apps/cnpg/cluster.yaml`
-- **Keycloak config**: `k8s/apps/keycloak/keycloak.yaml` (+ realm import in `k8s/apps/keycloak/realm-import.yaml`)
+- **Keycloak config**: `k8s/apps/keycloak/keycloak.yaml`
+  - The `KeycloakRealmImport` inside that manifest seeds the `rws` realm. After the Keycloak Operator imports the realm it
+    clears `spec.realm`, so Argo CD ignores differences on that path to avoid endless resyncs. When you change the realm
+    payload, bump `metadata.annotations.iam.demo/realm-config-version` so Argo CD reapplies the manifest and Keycloak
+    performs a fresh import.
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
 
 ---

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -38,6 +38,8 @@ kind: KeycloakRealmImport
 metadata:
   name: rws-realm-import
   namespace: iam
+  annotations:
+    iam.demo/realm-config-version: "1"
 spec:
   keycloakCRName: rws-keycloak
   realm:

--- a/k8s/argocd/apps.yaml
+++ b/k8s/argocd/apps.yaml
@@ -12,6 +12,13 @@ spec:
     repoURL: https://github.com/${REPO_OWNER}/${REPO_NAME}
     targetRevision: HEAD
     path: k8s/apps
+  ignoreDifferences:
+    - group: k8s.keycloak.org
+      kind: KeycloakRealmImport
+      name: rws-realm-import
+      namespace: iam
+      jsonPointers:
+        - /spec/realm
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- add an Argo CD ignoreDifferences rule for the KeycloakRealmImport so the operator clearing spec.realm no longer leaves the app OutOfSync
- version the realm import with an annotation so changing the realm payload still forces a fresh import
- document the new workflow in the README for cluster operators

## Testing
- `kustomize build k8s/apps` *(fails locally: command not found in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68cad22983b4832bbe351d602f75f44d