### PR TITLE
Fix Keycloak realm import webauthn fields

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -49,11 +49,10 @@ spec:
     loginWithEmailAllowed: true
     resetPasswordAllowed: true
     sslRequired: none
-    webAuthnPolicy:
-      rpEntityName: "RWS Demo"
-      userVerificationRequirement: "required"
-      createTimeout: 120000
-      avoidSameAuthenticatorRegister: true
+    webAuthnPolicyRpEntityName: "RWS Demo"
+    webAuthnPolicyUserVerificationRequirement: "required"
+    webAuthnPolicyCreateTimeout: 120000
+    webAuthnPolicyAvoidSameAuthenticatorRegister: true
     clients:
       - clientId: rws-midpoint
         name: rws-midpoint


### PR DESCRIPTION
## Summary
- align the Keycloak realm import manifest with the CRD field names so Argo CD stops reporting drift

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cad22983b4832bbe351d602f75f44d