### PR TITLE
Handle Keycloak realm import drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,15 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 - **Terraform vars**: `infra/azure/terraform/terraform.tfvars` (or via repo variables / workflow inputs)
 - **Helm/Argo versions**: see `k8s/addons/*/application.yaml`
 - **DB sizing**: `k8s/apps/cnpg/cluster.yaml`
-- **Keycloak config**: `k8s/apps/keycloak/keycloak.yaml` (+ realm import in `k8s/apps/keycloak/realm-import.yaml`)
+- **Keycloak config**: `k8s/apps/keycloak/keycloak.yaml` (+ realm import in `k8s/apps/keycloak/rws-realm.yaml`)
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
+
+
+### Keycloak realm GitOps notes
+
+- The Keycloak operator clears `spec.realm` on the `KeycloakRealmImport` after a successful import. Argo CD now ignores that field to prevent endless self-heal loops.
+- `k8s/apps/keycloak/rws-realm.yaml` holds the desired realm. A kustomize `vars` entry injects a checksum annotation into the import so Argo CD still detects changes and re-syncs when you edit the realm file.
+- `kustomize build k8s/apps` emits a deprecation warning about `vars`; this is expected for now and does not affect the rendered manifests.
 
 ---
 

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -32,36 +32,13 @@ spec:
       cpu: "1"
       memory: "2Gi"
 ---
-# Minimal realm import to create realm 'rws' and a demo client
 apiVersion: k8s.keycloak.org/v2alpha1
 kind: KeycloakRealmImport
 metadata:
   name: rws-realm-import
   namespace: iam
+  annotations:
+    iam.evolveum.com/realm-checksum: $(REALM_CHECKSUM)
 spec:
   keycloakCRName: rws-keycloak
-  realm:
-    id: rws
-    realm: rws
-    displayName: RWS Demo
-    enabled: true
-    registrationAllowed: false
-    loginWithEmailAllowed: true
-    resetPasswordAllowed: true
-    sslRequired: none
-    webAuthnPolicy:
-      rpEntityName: "RWS Demo"
-      userVerificationRequirement: "required"
-      createTimeout: 120000
-      avoidSameAuthenticatorRegister: true
-    clients:
-      - clientId: rws-midpoint
-        name: rws-midpoint
-        protocol: openid-connect
-        publicClient: true
-        directAccessGrantsEnabled: true
-        standardFlowEnabled: true
-        redirectUris:
-          - "http://*/midpoint/*"
-        webOrigins:
-          - "*"
+  realm: {}

--- a/k8s/apps/keycloak/rws-realm.yaml
+++ b/k8s/apps/keycloak/rws-realm.yaml
@@ -1,0 +1,31 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: rws-realm-import
+  namespace: iam
+spec:
+  realm:
+    id: rws
+    realm: rws
+    displayName: RWS Demo
+    enabled: true
+    registrationAllowed: false
+    loginWithEmailAllowed: true
+    resetPasswordAllowed: true
+    sslRequired: none
+    webAuthnPolicy:
+      rpEntityName: "RWS Demo"
+      userVerificationRequirement: "required"
+      createTimeout: 120000
+      avoidSameAuthenticatorRegister: true
+    clients:
+      - clientId: rws-midpoint
+        name: rws-midpoint
+        protocol: openid-connect
+        publicClient: true
+        directAccessGrantsEnabled: true
+        standardFlowEnabled: true
+        redirectUris:
+          - "http://*/midpoint/*"
+        webOrigins:
+          - "*"

--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -3,3 +3,24 @@ kind: Kustomization
 resources:
   - keycloak/keycloak.yaml
   - midpoint/deployment.yaml
+patches:
+  - path: keycloak/rws-realm.yaml
+    target:
+      kind: KeycloakRealmImport
+      name: rws-realm-import
+configMapGenerator:
+  - name: rws-realm-import-checksum
+    files:
+      - realm.yaml=keycloak/rws-realm.yaml
+    options:
+      disableNameSuffixHash: false
+      annotations:
+        argocd.argoproj.io/sync-options: Skip=true
+vars:
+  - name: REALM_CHECKSUM
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: rws-realm-import-checksum
+    fieldref:
+      fieldpath: metadata.name

--- a/k8s/argocd/apps.yaml
+++ b/k8s/argocd/apps.yaml
@@ -12,6 +12,13 @@ spec:
     repoURL: https://github.com/${REPO_OWNER}/${REPO_NAME}
     targetRevision: HEAD
     path: k8s/apps
+  ignoreDifferences:
+    - group: k8s.keycloak.org
+      kind: KeycloakRealmImport
+      name: rws-realm-import
+      namespace: iam
+      jsonPointers:
+        - /spec/realm
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- split the Keycloak realm definition into its own patch and add a checksum annotation so Argo CD can detect updates without fighting the operator
- configure the Argo CD application to ignore KeycloakRealmImport spec drift and document the new workflow for maintaining the realm import

## Testing
- kustomize build k8s/apps

------
https://chatgpt.com/codex/tasks/task_e_68cad22983b4832bbe351d602f75f44d