### PR TITLE
Fix SQL heredoc indentation in bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -732,20 +732,20 @@ spec:
                   EXECUTE format('ALTER ROLE %I LOGIN', role_name);
                 END IF;
               END
-              $do$;
+                $do$;
 
-              DO $do$
-              DECLARE
-                role_name text := :'mp_user';
-              BEGIN
-                IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint') THEN
-                  EXECUTE format('CREATE DATABASE %I OWNER %I', 'midpoint', role_name);
-                ELSE
-                  EXECUTE format('ALTER DATABASE %I OWNER TO %I', 'midpoint', role_name);
-                END IF;
-              END
-              $do$;
-SQL
+                DO $do$
+                DECLARE
+                  role_name text := :'mp_user';
+                BEGIN
+                  IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint') THEN
+                    EXECUTE format('CREATE DATABASE %I OWNER %I', 'midpoint', role_name);
+                  ELSE
+                    EXECUTE format('ALTER DATABASE %I OWNER TO %I', 'midpoint', role_name);
+                  END IF;
+                END
+                $do$;
+                SQL
 YAML
 
           export NS="${ns}"


### PR DESCRIPTION
## Summary
- indent the SQL heredoc terminator inside the midPoint database bootstrap job manifest so the generated YAML parses correctly

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cb01f2e20c832ba9a96e5730dd4a3b