### PR TITLE
Fix GitHub Actions workflow YAML indentation

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -680,73 +680,73 @@ jobs:
           }
           trap cleanup_manifest EXIT
 
-          cat <<'YAML' >"${manifest}"
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: midpoint-db-bootstrap
-  namespace: ${NS}
-spec:
-  backoffLimit: 3
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: psql
-          image: ghcr.io/cloudnative-pg/postgresql:16.4
-          env:
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: cnpg-superuser
-                  key: password
-            - name: MIDPOINT_DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: midpoint-db-app
-                  key: username
-            - name: MIDPOINT_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: midpoint-db-app
-                  key: password
-            - name: DB_HOST
-              value: iam-db-rw.${NS}.svc.cluster.local
-          command:
-            - bash
-            - -lc
-            - |
-              set -euo pipefail
-              psql -h "${DB_HOST}" -U postgres -v ON_ERROR_STOP=1 \
-                --set=mp_user="${MIDPOINT_DB_USER}" \
-                --set=mp_password="${MIDPOINT_DB_PASSWORD}" <<'SQL'
-              DO $do$
-              DECLARE
-                role_name text := :'mp_user';
-                role_password text := :'mp_password';
-              BEGIN
-                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
-                  EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_password);
-                ELSE
-                  EXECUTE format('ALTER ROLE %I PASSWORD %L', role_name, role_password);
-                  EXECUTE format('ALTER ROLE %I LOGIN', role_name);
-                END IF;
-              END
-                $do$;
+          cat <<'YAML' | sed 's/^          //' >"${manifest}"
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: midpoint-db-bootstrap
+            namespace: ${NS}
+          spec:
+            backoffLimit: 3
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: psql
+                    image: ghcr.io/cloudnative-pg/postgresql:16.4
+                    env:
+                      - name: PGPASSWORD
+                        valueFrom:
+                          secretKeyRef:
+                            name: cnpg-superuser
+                            key: password
+                      - name: MIDPOINT_DB_USER
+                        valueFrom:
+                          secretKeyRef:
+                            name: midpoint-db-app
+                            key: username
+                      - name: MIDPOINT_DB_PASSWORD
+                        valueFrom:
+                          secretKeyRef:
+                            name: midpoint-db-app
+                            key: password
+                      - name: DB_HOST
+                        value: iam-db-rw.${NS}.svc.cluster.local
+                    command:
+                      - bash
+                      - -lc
+                      - |
+                        set -euo pipefail
+                        psql -h "${DB_HOST}" -U postgres -v ON_ERROR_STOP=1 \
+                          --set=mp_user="${MIDPOINT_DB_USER}" \
+                          --set=mp_password="${MIDPOINT_DB_PASSWORD}" <<'SQL'
+                        DO $do$
+                        DECLARE
+                          role_name text := :'mp_user';
+                          role_password text := :'mp_password';
+                        BEGIN
+                          IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+                            EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_password);
+                          ELSE
+                            EXECUTE format('ALTER ROLE %I PASSWORD %L', role_name, role_password);
+                            EXECUTE format('ALTER ROLE %I LOGIN', role_name);
+                          END IF;
+                        END
+                          $do$;
 
-                DO $do$
-                DECLARE
-                  role_name text := :'mp_user';
-                BEGIN
-                  IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint') THEN
-                    EXECUTE format('CREATE DATABASE %I OWNER %I', 'midpoint', role_name);
-                  ELSE
-                    EXECUTE format('ALTER DATABASE %I OWNER TO %I', 'midpoint', role_name);
-                  END IF;
-                END
-                $do$;
-                SQL
-YAML
+                          DO $do$
+                          DECLARE
+                            role_name text := :'mp_user';
+                          BEGIN
+                            IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint') THEN
+                              EXECUTE format('CREATE DATABASE %I OWNER %I', 'midpoint', role_name);
+                            ELSE
+                              EXECUTE format('ALTER DATABASE %I OWNER TO %I', 'midpoint', role_name);
+                            END IF;
+                          END
+                          $do$;
+                          SQL
+          YAML
           export NS="${ns}"
           envsubst '$NS' < "${manifest}" | kubectl apply -f -
 


### PR DESCRIPTION
## Summary
- indent the midPoint bootstrap job manifest heredoc so the workflow YAML parses
- pipe the heredoc through sed to strip the helper indentation before writing the manifest

## Testing
- python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68cb04bafb28832b9b462bc3f55cd442