### PR TITLE
Fix CNPG superuser secret creation

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -372,15 +372,19 @@ jobs:
           set -euo pipefail
 
           kubectl -n ${{ inputs.NAMESPACE_IAM }} create secret generic cnpg-superuser \
+            --type=kubernetes.io/basic-auth \
+            --from-literal=username='postgres' \
             --from-literal=password='${{ secrets.POSTGRES_SUPERUSER_PASSWORD }}' \
             --dry-run=client -o yaml | kubectl apply -f -
 
           kubectl -n ${{ inputs.NAMESPACE_IAM }} create secret generic keycloak-db-app \
+            --type=kubernetes.io/basic-auth \
             --from-literal=username='keycloak' \
             --from-literal=password='${{ secrets.KEYCLOAK_DB_PASSWORD }}' \
             --dry-run=client -o yaml | kubectl apply -f -
 
           kubectl -n ${{ inputs.NAMESPACE_IAM }} create secret generic midpoint-db-app \
+            --type=kubernetes.io/basic-auth \
             --from-literal=username='midpoint' \
             --from-literal=password='${{ secrets.MIDPOINT_DB_PASSWORD }}' \
             --dry-run=client -o yaml | kubectl apply -f -
@@ -435,6 +439,7 @@ jobs:
             fi
           }
 
+          check_secret_key cnpg-superuser username
           check_secret_key cnpg-superuser password
           check_secret_key keycloak-db-app username
           check_secret_key keycloak-db-app password

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - (Optional) `LOCATION` – default `westeurope`
   - (Optional) `RESOURCE_PREFIX` – short prefix, default `rwsdemo`
   - **DB secrets** (you can change later):
-    - `POSTGRES_SUPERUSER_PASSWORD` – password for CNPG `postgres`
+    - `POSTGRES_SUPERUSER_PASSWORD` – password for CNPG `postgres` (workflow stores it in a `kubernetes.io/basic-auth` secret with username `postgres`)
     - `KEYCLOAK_DB_PASSWORD` – password for DB user `keycloak`
     - `MIDPOINT_DB_PASSWORD` – password for DB user `midpoint`
   - **midPoint admin**: `MIDPOINT_ADMIN_PASSWORD` – initial `administrator` password


### PR DESCRIPTION
## Summary
- ensure the bootstrap workflow creates CloudNativePG application and superuser secrets as `kubernetes.io/basic-auth` entries with explicit usernames so password reconciliation succeeds
- add a prerequisite check that validates the `cnpg-superuser` secret carries a username key and document the behavior for operators in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb0fbea36c832baf00285fae5f5d53