### PR TITLE
Ensure CNPG Azure backups path is clean before bootstrap

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -402,6 +402,87 @@ jobs:
             --from-literal=AZURE_STORAGE_KEY="$AZURE_STORAGE_KEY" \
             --dry-run=client -o yaml | kubectl apply -f -
 
+      - name: Purge existing CNPG Azure backup prefix
+        shell: bash
+        env:
+          AZURE_STORAGE_ACCOUNT: ${{ inputs.STORAGE_ACCOUNT }}
+          AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+        run: |
+          set -euo pipefail
+
+          container="cnpg-backups"
+          prefix="iam-db"
+
+          if [ -z "${AZURE_STORAGE_ACCOUNT}" ]; then
+            echo "STORAGE_ACCOUNT input must not be empty"
+            exit 1
+          fi
+
+          if [ -z "${AZURE_STORAGE_KEY}" ]; then
+            echo "AZURE_STORAGE_KEY secret missing; skipping Azure backup purge"
+            exit 0
+          fi
+
+          echo "Ensuring Azure Blob container ${container} exists in account ${AZURE_STORAGE_ACCOUNT}"
+          container_exists=$(az storage container exists \
+            --name "${container}" \
+            --account-name "${AZURE_STORAGE_ACCOUNT}" \
+            --account-key "${AZURE_STORAGE_KEY}" \
+            --query exists -o tsv 2>/dev/null || true)
+
+          if [ "${container_exists}" != "true" ]; then
+            echo "Azure container ${container} not found; creating it"
+            az storage container create \
+              --name "${container}" \
+              --account-name "${AZURE_STORAGE_ACCOUNT}" \
+              --account-key "${AZURE_STORAGE_KEY}" \
+              --public-access off 1>/dev/null
+          fi
+
+          echo "Checking for leftover WAL/archive objects under ${container}/${prefix}"
+          existing_count=$(az storage blob list \
+            --account-name "${AZURE_STORAGE_ACCOUNT}" \
+            --account-key "${AZURE_STORAGE_KEY}" \
+            --container-name "${container}" \
+            --prefix "${prefix}/" \
+            --query "length(@)" -o tsv 2>/dev/null || echo 0)
+
+          if [ "${existing_count}" = "" ]; then
+            existing_count=0
+          fi
+
+          if [ "${existing_count}" -eq 0 ]; then
+            echo "Azure backup prefix ${prefix}/ is already empty"
+            exit 0
+          fi
+
+          echo "Deleting ${existing_count} Azure Blob object(s) under ${prefix}/ before bootstrapping CNPG"
+          az storage blob delete-batch \
+            --account-name "${AZURE_STORAGE_ACCOUNT}" \
+            --account-key "${AZURE_STORAGE_KEY}" \
+            --source "${container}" \
+            --pattern "${prefix}/*" \
+            --no-progress
+
+          echo "Verifying Azure backup prefix ${prefix}/ is now empty"
+          remaining_count=$(az storage blob list \
+            --account-name "${AZURE_STORAGE_ACCOUNT}" \
+            --account-key "${AZURE_STORAGE_KEY}" \
+            --container-name "${container}" \
+            --prefix "${prefix}/" \
+            --query "length(@)" -o tsv 2>/dev/null || echo 0)
+
+          if [ "${remaining_count}" = "" ]; then
+            remaining_count=0
+          fi
+
+          if [ "${remaining_count}" -ne 0 ]; then
+            echo "Failed to purge Azure backup prefix ${prefix}/ (still ${remaining_count} object(s) present)"
+            exit 1
+          fi
+
+          echo "Azure backup prefix ${prefix}/ successfully emptied"
+
       - name: Validate CNPG prerequisites
         env:
           NAMESPACE_IAM: ${{ inputs.NAMESPACE_IAM }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Install **Keycloak Operator** then create a **Keycloak** CR bound to CNPG
    - Deploy **midPoint** bound to CNPG
    - Create a Kubernetes **Secret** with Azure Blob credentials (from repo secrets) for CNPG backups
+   - Purge any existing WAL/archive blobs in the Azure `cnpg-backups/iam-db` prefix so CloudNativePG can bootstrap cleanly on reruns
 
 > By default, services are plain HTTP for simplicity and use **`nip.io`** hostnames you can visit from your browser.
 

--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -30,7 +30,7 @@ spec:
   backup:
     retentionPolicy: "7d"
     barmanObjectStore:
-      destinationPath: "https://{{STORAGE_ACCOUNT}}.blob.core.windows.net/cnpg-backups/iam-db"
+      destinationPath: "https://{{STORAGE_ACCOUNT}}.blob.core.windows.net/cnpg-backups/iam-db/"
       azureCredentials:
         storageAccount:
           name: cnpg-azure-backup


### PR DESCRIPTION
## Summary
- add a bootstrap step that clears the Azure Blob prefix used for CloudNativePG WAL/archive data before applying the cluster manifest
- document the new automation in the bootstrap README instructions and align the manifest URL with a trailing slash to match Azure samples

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cb0fbea36c832baf00285fae5f5d53