### PR TITLE
Handle SAS tokens in CNPG Azure backup purge workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -474,16 +474,26 @@ jobs:
           echo "Ensuring Azure Blob container ${container} exists in account ${AZURE_STORAGE_ACCOUNT}"
 
           use_connection_string=false
+          use_sas_token=false
           if [[ "${AZURE_STORAGE_KEY}" == *"DefaultEndpointsProtocol="* ]] || \
              [[ "${AZURE_STORAGE_KEY}" == *"AccountKey="* ]] || \
              [[ "${AZURE_STORAGE_KEY}" == *"BlobEndpoint="* ]]; then
             use_connection_string=true
             echo "AZURE_STORAGE_KEY appears to be an Azure Storage connection string; using it for az storage commands"
+          else
+            sas_candidate="${AZURE_STORAGE_KEY#\?}"
+            if [[ "${sas_candidate}" == *"sig="* ]] && [[ "${sas_candidate}" == *"sv="* ]]; then
+              use_sas_token=true
+              echo "AZURE_STORAGE_KEY appears to be an Azure Storage SAS token; using it for az storage commands"
+            fi
           fi
 
           az_auth_args=()
           if [ "${use_connection_string}" = true ]; then
             az_auth_args+=("--connection-string" "${AZURE_STORAGE_KEY}")
+          elif [ "${use_sas_token}" = true ]; then
+            sas_token="${AZURE_STORAGE_KEY#\?}"
+            az_auth_args+=("--account-name" "${AZURE_STORAGE_ACCOUNT}" "--sas-token" "${sas_token}")
           else
             az_auth_args+=("--account-name" "${AZURE_STORAGE_ACCOUNT}" "--account-key" "${AZURE_STORAGE_KEY}")
           fi


### PR DESCRIPTION
## Summary
- detect Azure Storage SAS tokens in the CNPG purge step and authenticate az storage commands with --sas-token
- keep support for connection strings and account keys to avoid failing when creating the backup container

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb1a8d2fc8832b810d47aca4adc558