### PR TITLE
Fix midpoint DB bootstrap SQL heredoc indentation

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1223,9 +1223,9 @@ jobs:
                             EXECUTE format('ALTER ROLE %I LOGIN', role_name);
                           END IF;
                         END
-                          $do$;
+                        $do$;
 
-                          DO $do$
+                        DO $do$
                           DECLARE
                             role_name text := :'mp_user';
                           BEGIN
@@ -1235,8 +1235,8 @@ jobs:
                               EXECUTE format('ALTER DATABASE %I OWNER TO %I', 'midpoint', role_name);
                             END IF;
                           END
-                          $do$;
-                          SQL
+                        $do$;
+                        SQL
           YAML
           export NS="${ns}"
           envsubst '$NS' < "${manifest}" | kubectl apply -f -


### PR DESCRIPTION
## Summary
- align the CloudNativePG bootstrap job's SQL heredoc delimiter so it closes correctly when rendered
- prevent the midpoint database/bootstrap job from feeding the literal `SQL` line to psql, which blocked role and database creation

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb2b4c3e00832b983a949cd9053e40