### PR TITLE
Refine midPoint DB bootstrap job manifest

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1414,75 +1414,18 @@ jobs:
           }
           trap cleanup_manifest EXIT
 
-          cat <<'YAML' | sed 's/^          //' >"${manifest}"
-          apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: midpoint-db-bootstrap
-            namespace: ${NS}
-          spec:
-            backoffLimit: 3
-            template:
-              spec:
-                restartPolicy: Never
-                containers:
-                  - name: psql
-                    image: ghcr.io/cloudnative-pg/postgresql:16.4
-                    env:
-                      - name: PGPASSWORD
-                        valueFrom:
-                          secretKeyRef:
-                            name: cnpg-superuser
-                            key: password
-                      - name: MIDPOINT_DB_USER
-                        valueFrom:
-                          secretKeyRef:
-                            name: midpoint-db-app
-                            key: username
-                      - name: MIDPOINT_DB_PASSWORD
-                        valueFrom:
-                          secretKeyRef:
-                            name: midpoint-db-app
-                            key: password
-                      - name: DB_HOST
-                        value: iam-db-rw.${NS}.svc.cluster.local
-                    command:
-                      - bash
-                      - -lc
-                      - |
-                        set -euo pipefail
-                        psql -h "${DB_HOST}" -U postgres -v ON_ERROR_STOP=1 \
-                          --set=mp_user="${MIDPOINT_DB_USER}" \
-                          --set=mp_password="${MIDPOINT_DB_PASSWORD}" <<'SQL'
-                        DO $do$
-                        DECLARE
-                          role_name text := :'mp_user';
-                          role_password text := :'mp_password';
-                        BEGIN
-                          IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
-                            EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_password);
-                          ELSE
-                            EXECUTE format('ALTER ROLE %I PASSWORD %L', role_name, role_password);
-                            EXECUTE format('ALTER ROLE %I LOGIN', role_name);
-                          END IF;
-                        END
-                        $do$;
+          if ! sed "s#{{NAMESPACE}}#${ns}#g" k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml >"${manifest}"; then
+            echo "Failed to render midpoint database bootstrap Job manifest"
+            exit 1
+          fi
 
-                        DO $do$
-                          DECLARE
-                            role_name text := :'mp_user';
-                          BEGIN
-                            IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint') THEN
-                              EXECUTE format('CREATE DATABASE %I OWNER %I', 'midpoint', role_name);
-                            ELSE
-                              EXECUTE format('ALTER DATABASE %I OWNER TO %I', 'midpoint', role_name);
-                            END IF;
-                          END
-                        $do$;
-                        SQL
-          YAML
-          export NS="${ns}"
-          envsubst '$NS' < "${manifest}" | kubectl apply -f -
+          if grep -q '{{NAMESPACE}}' "${manifest}"; then
+            echo "Namespace placeholder substitution failed for midpoint database bootstrap Job manifest"
+            cat "${manifest}"
+            exit 1
+          fi
+
+          kubectl apply -f "${manifest}"
 
           if ! kubectl -n "${ns}" wait --for=condition=Complete job/"${job_name}" --timeout=240s; then
             echo "midPoint database bootstrap job did not complete successfully"

--- a/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
+++ b/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: midpoint-db-bootstrap
+  namespace: {{NAMESPACE}}
+  labels:
+    app.kubernetes.io/name: midpoint-db-bootstrap
+    app.kubernetes.io/component: database-bootstrap
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: midpoint-db-bootstrap
+      app.kubernetes.io/component: database-bootstrap
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: midpoint-db-bootstrap
+        app.kubernetes.io/component: database-bootstrap
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ghcr.io/cloudnative-pg/postgresql:16.4
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cnpg-superuser
+                  key: password
+            - name: MIDPOINT_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-db-app
+                  key: username
+            - name: MIDPOINT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-db-app
+                  key: password
+            - name: DB_HOST
+              value: iam-db-rw.{{NAMESPACE}}.svc.cluster.local
+          command:
+            - bash
+            - -lc
+            - |
+              set -euo pipefail
+
+              psql -h "${DB_HOST}" -U postgres -v ON_ERROR_STOP=1 \
+                --set=mp_user="${MIDPOINT_DB_USER}" \
+                --set=mp_password="${MIDPOINT_DB_PASSWORD}" <<'SQL'
+              DO $do$
+              DECLARE
+                role_name text := :'mp_user';
+                role_password text := :'mp_password';
+              BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+                  EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_password);
+                ELSE
+                  EXECUTE format('ALTER ROLE %I PASSWORD %L', role_name, role_password);
+                  EXECUTE format('ALTER ROLE %I LOGIN', role_name);
+                END IF;
+              END
+              $do$;
+
+              DO $do$
+                DECLARE
+                  role_name text := :'mp_user';
+                BEGIN
+                  IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint') THEN
+                    EXECUTE format('CREATE DATABASE %I OWNER %I', 'midpoint', role_name);
+                  ELSE
+                    EXECUTE format('ALTER DATABASE %I OWNER TO %I', 'midpoint', role_name);
+                  END IF;
+                END
+              $do$;
+              SQL


### PR DESCRIPTION
## Summary
- add a reusable Job manifest for bootstrapping the midPoint database
- render the manifest in the bootstrap workflow instead of inlining YAML and validate placeholder replacement

## Testing
- sed 's/{{NAMESPACE}}/iam/g' k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml | ./kubeconform -summary -

------
https://chatgpt.com/codex/tasks/task_e_68cbb3095fa4832b8c7aa729f3f2e8ed