### PR TITLE
Handle Azure CLI delete-batch without no-progress flag

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -906,7 +906,15 @@ jobs:
           fi
 
           echo "Deleting ${existing_count} Azure Blob object(s) under ${prefix}/ before bootstrapping CNPG"
-          run_az_storage_command no-capture "deleting blobs under ${prefix}/" blob delete-batch --source "${container}" --pattern "${prefix}/*" --no-progress
+
+          delete_batch_flags=()
+          if az storage blob delete-batch --help 2>&1 | grep -Fq -- '--no-progress'; then
+            delete_batch_flags+=("--no-progress")
+          else
+            echo "Azure CLI delete-batch command does not support --no-progress; continuing without it."
+          fi
+
+          run_az_storage_command no-capture "deleting blobs under ${prefix}/" blob delete-batch --source "${container}" --pattern "${prefix}/*" "${delete_batch_flags[@]}"
 
           echo "Verifying Azure backup prefix ${prefix}/ is now empty"
           remaining_count="$(run_az_storage_command capture "verifying blob cleanup" blob list --container-name "${container}" --prefix "${prefix}/" --query 'length(@)' -o tsv)"


### PR DESCRIPTION
## Summary
- detect whether `az storage blob delete-batch` still supports `--no-progress`
- fall back to running the cleanup without that flag while logging the behavior

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cbbd933020832b98fa94521c281802