### PR TITLE
Fix midpoint DB bootstrap Job selector

### DIFF
--- a/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
+++ b/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
@@ -9,10 +9,6 @@ metadata:
 spec:
   backoffLimit: 3
   ttlSecondsAfterFinished: 600
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: midpoint-db-bootstrap
-      app.kubernetes.io/component: database-bootstrap
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary
- remove the manual selector from the midpoint DB bootstrap Job so Kubernetes can create the selector automatically

## Testing
- not run (manifest-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cbe938b1d8832bb26a90b752f0fd8b