### PR TITLE
Fix midpoint database bootstrap quoting

### DIFF
--- a/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
+++ b/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
@@ -43,22 +43,33 @@ spec:
             - |
               set -euo pipefail
 
-              psql -h "${DB_HOST}" -U postgres -v ON_ERROR_STOP=1 \
-                --set=mp_user="${MIDPOINT_DB_USER}" \
-                --set=mp_password="${MIDPOINT_DB_PASSWORD}" <<'SQL'
-              SELECT CASE
-                       WHEN NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'mp_user') THEN
-                         format('CREATE ROLE %I LOGIN PASSWORD %L', :'mp_user', :'mp_password')
-                       ELSE
-                         format('ALTER ROLE %I PASSWORD %L; ALTER ROLE %I LOGIN', :'mp_user', :'mp_password', :'mp_user')
-                     END AS command;
-              \gexec
+              mp_user_sql=${MIDPOINT_DB_USER//\'/\'\'}
+              mp_password_sql=${MIDPOINT_DB_PASSWORD//\'/\'\'}
 
-              SELECT CASE
-                       WHEN NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint') THEN
-                         format('CREATE DATABASE %I OWNER %I', 'midpoint', :'mp_user')
-                       ELSE
-                         format('ALTER DATABASE %I OWNER TO %I', 'midpoint', :'mp_user')
-                     END AS command;
-              \gexec
+              psql -h "${DB_HOST}" -U postgres -v ON_ERROR_STOP=1 <<SQL
+              DO \$\$
+              DECLARE
+                role_name text := '${mp_user_sql}';
+                role_password text := '${mp_password_sql}';
+              BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+                  EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_password);
+                ELSE
+                  EXECUTE format('ALTER ROLE %I PASSWORD %L', role_name, role_password);
+                  EXECUTE format('ALTER ROLE %I LOGIN', role_name);
+                END IF;
+              END
+              \$\$;
+
+              DO \$\$
+              DECLARE
+                role_name text := '${mp_user_sql}';
+              BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint') THEN
+                  EXECUTE format('CREATE DATABASE %I OWNER %I', 'midpoint', role_name);
+                ELSE
+                  EXECUTE format('ALTER DATABASE %I OWNER TO %I', 'midpoint', role_name);
+                END IF;
+              END
+              \$\$;
               SQL


### PR DESCRIPTION
## Summary
- escape the midpoint database credentials in the bootstrap job before generating SQL
- execute the role and database creation logic via DO blocks so the job no longer depends on psql variable substitution

## Testing
- not run (Kubernetes manifest change only)


------
https://chatgpt.com/codex/tasks/task_e_68cbfe2a8014832b8f3879fdf94dd66e