### PR TITLE
Ensure midPoint database has required PostgreSQL extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
      - The workflow pre-installs CloudNativePG CRDs with `kubectl apply --server-side`. It first attempts to render them via `helm show crds` and, if the chart does not publish CRDs in that location (as happens with recent releases), falls back to `helm template --include-crds` and filters the `CustomResourceDefinition` manifests. This keeps the large schemas out of Kubernetes' annotation history while the Argo CD application disables chart-managed CRDs (`crds.create=false`) to avoid reintroducing the oversized annotation.
    - Create **CNPG** cluster `iam-db` (+ Azure Blob backup config)
    - Run a one-off PostgreSQL job that ensures the `midpoint` database and role exist before midPoint starts
+   - Enable the required PostgreSQL extensions (`pgcrypto`, `pg_trgm`) for midPoint
    - Install **Keycloak Operator** then create a **Keycloak** CR bound to CNPG
    - Deploy **midPoint** bound to CNPG
    - Create a Kubernetes **Secret** with Azure Blob credentials (from repo secrets) for CNPG backups

--- a/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
+++ b/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
@@ -73,3 +73,9 @@ spec:
               END
               \$\$;
               SQL
+
+              echo "Ensuring required extensions exist in database 'midpoint'"
+              psql -h "${DB_HOST}" -U postgres -d midpoint -v ON_ERROR_STOP=1 <<'SQL'
+              CREATE EXTENSION IF NOT EXISTS pgcrypto;
+              CREATE EXTENSION IF NOT EXISTS pg_trgm;
+              SQL


### PR DESCRIPTION
## Summary
- update the midpoint database bootstrap job to install the pgcrypto and pg_trgm extensions
- document that the bootstrap workflow now enables the required PostgreSQL extensions for midPoint

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc11de3fec832ba9d16d3581217408