### PR TITLE
Tune midPoint memory to avoid crash loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     performs a fresh import.
 
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
+  - The deployment constrains the JVM heap (`MP_MEM_INIT=768M`, `MP_MEM_MAX=1536M`) so the pod fits on the small demo
+    nodes. Bump these values together with the container `resources` block if you size the cluster up.
 
 
 ### Keycloak realm GitOps notes

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -28,12 +28,23 @@ spec:
                 secretKeyRef:
                   name: midpoint-db-app
                   key: password
+            - name: MP_MEM_INIT
+              value: "768M"
+            - name: MP_MEM_MAX
+              value: "1536M"
           volumeMounts:
             - name: midpoint-home
               mountPath: /opt/midpoint/var
             - name: config-xml
               mountPath: /opt/midpoint/var/config.xml
               subPath: config.xml
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
       volumes:
         - name: midpoint-home
           emptyDir: {}


### PR DESCRIPTION
## Summary
- cap the midPoint JVM heap and declare container resources so the pod fits on the small AKS demo nodes
- document the new heap knobs in the README for operators that resize the cluster

## Testing
- `kustomize build k8s/apps` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc11de3fec832ba9d16d3581217408