### PR TITLE
Ensure pgcrypto extension exists for midPoint

### DIFF
--- a/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
+++ b/k8s/apps/cnpg/midpoint-db-bootstrap-job.yaml
@@ -73,3 +73,16 @@ spec:
               END
               \$\$;
               SQL
+
+              psql -h "${DB_HOST}" -U postgres -d midpoint -v ON_ERROR_STOP=1 \
+                -c "CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;"
+
+              psql -h "${DB_HOST}" -U postgres -d midpoint -v ON_ERROR_STOP=1 <<SQL
+              DO \$\$
+              DECLARE
+                role_name text := '${mp_user_sql}';
+              BEGIN
+                EXECUTE format('ALTER EXTENSION pgcrypto OWNER TO %I', role_name);
+              END
+              \$\$;
+              SQL


### PR DESCRIPTION
## Summary
- ensure the midpoint database bootstrap job creates the pgcrypto extension so the application can use encrypted columns
- transfer ownership of the extension to the midpoint role to keep privileges consistent on re-runs

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc11de3fec832ba9d16d3581217408