### PR TITLE
Switch midPoint config to native PostgreSQL repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
   - The deployment constrains the JVM heap (`MP_MEM_INIT=768M`, `MP_MEM_MAX=1536M`) so the pod fits on the small demo
     nodes. Bump these values together with the container `resources` block if you size the cluster up.
+  - `config.xml` uses the **native PostgreSQL repository** (Sqale) recommended for midPoint 4.9 and later, which
+    matches the CloudNativePG PostgreSQL 16 cluster created by the automation.
 
 
 ### Keycloak realm GitOps notes

--- a/k8s/apps/midpoint/config.xml
+++ b/k8s/apps/midpoint/config.xml
@@ -1,13 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration xmlns="http://midpoint.evolveum.com/xml/ns/public/common/configuration-3">
   <midpoint>
+    <webApplication>
+      <importFolder>${midpoint.home}/import</importFolder>
+    </webApplication>
     <repository>
-      <type>postgresql</type>
+      <type>native</type>
       <jdbcUrl>jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint</jdbcUrl>
       <jdbcUsername>midpoint</jdbcUsername>
       <jdbcPassword>${env.MIDPOINT_DB_PASSWORD}</jdbcPassword>
-      <driverClassName>org.postgresql.Driver</driverClassName>
-      <hibernateHbm2ddl>update</hibernateHbm2ddl>
     </repository>
+    <audit>
+      <auditService>
+        <auditServiceFactoryClass>com.evolveum.midpoint.audit.impl.LoggerAuditServiceFactory</auditServiceFactoryClass>
+      </auditService>
+      <auditService>
+        <auditServiceFactoryClass>com.evolveum.midpoint.repo.sqale.audit.SqaleAuditServiceFactory</auditServiceFactoryClass>
+      </auditService>
+    </audit>
+    <icf>
+      <scanClasspath>true</scanClasspath>
+      <scanDirectory>${midpoint.home}/icf-connectors</scanDirectory>
+      <scanDirectory>${midpoint.home}/connid-connectors</scanDirectory>
+    </icf>
+    <keystore>
+      <keyStorePath>${midpoint.home}/keystore.jceks</keyStorePath>
+      <keyStorePassword>changeit</keyStorePassword>
+      <encryptionKeyAlias>default</encryptionKeyAlias>
+    </keystore>
   </midpoint>
 </configuration>


### PR DESCRIPTION
## Summary
- update the midPoint configuration to use the native PostgreSQL (Sqale) repository and include supporting audit/icf defaults
- document in the README that the bundled config targets the native repository on CloudNativePG PostgreSQL 16

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc1b166ebc832baf71e4ba963cb081