### PR TITLE
Generate midpoint config map via kustomize

### DIFF
--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - keycloak/keycloak.yaml
-  - midpoint/deployment.yaml
+  - midpoint
 patches:
   - path: keycloak/rws-realm.yaml
     target:

--- a/k8s/apps/midpoint/kustomization.yaml
+++ b/k8s/apps/midpoint/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: iam
+
+resources:
+  - deployment.yaml
+  - precreate.yaml
+
+configMapGenerator:
+  - name: midpoint-config
+    files:
+      - config.xml
+    options:
+      disableNameSuffixHash: true

--- a/k8s/apps/midpoint/precreate.yaml
+++ b/k8s/apps/midpoint/precreate.yaml
@@ -6,12 +6,3 @@ metadata:
 type: Opaque
 stringData:
   password: CHANGEME
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: midpoint-config
-  namespace: iam
-data:
-  config.xml: |
-    (placeholder) – replaced by deployment.yaml volume from ConfigMap


### PR DESCRIPTION
## Summary
- add a kustomization for the midpoint resources so that the config map is generated from the checked in config.xml
- remove the placeholder config map and reference the midpoint directory from the top-level kustomization

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc1b166ebc832baf71e4ba963cb081