### PR TITLE
Add init container to populate midPoint home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     nodes. Bump these values together with the container `resources` block if you size the cluster up.
   - `config.xml` uses the **native PostgreSQL repository** (Sqale) recommended for midPoint 4.9 and later, which
     matches the CloudNativePG PostgreSQL 16 cluster created by the automation.
+  - An init container now copies the default `/opt/midpoint/var` contents from the image into the writable volume used for
+    `midpoint.home`. This preserves the bundled keystore and directory structure so the server can start cleanly even when the
+    pod is rescheduled onto a fresh node.
 
 
 ### Keycloak realm GitOps notes

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -11,6 +11,29 @@ spec:
     metadata:
       labels: { app: midpoint }
     spec:
+      initContainers:
+        - name: midpoint-home-init
+          image: evolveum/midpoint:4.9
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              dest="/midpoint-home"
+              if [ ! -d "${dest}" ]; then
+                echo "Creating midPoint home directory at ${dest}"
+                mkdir -p "${dest}"
+              fi
+
+              if [ -z "$(ls -A "${dest}")" ]; then
+                echo "Populating midPoint home directory with default contents"
+                cp -a /opt/midpoint/var/. "${dest}/"
+              else
+                echo "midPoint home directory already populated; skipping default copy"
+              fi
+          volumeMounts:
+            - name: midpoint-home
+              mountPath: /midpoint-home
       containers:
         - name: midpoint
           image: evolveum/midpoint:4.9


### PR DESCRIPTION
## Summary
- add an init container to the midPoint deployment so the writable home volume contains the image defaults (keystore, structure) before the app starts
- document the init container behavior in the README for operators

## Testing
- ./kustomize build k8s/apps

------
https://chatgpt.com/codex/tasks/task_e_68cc2e144d88832b98ef7240f97d4fb3