### PR TITLE
Configure midPoint deployment to use PostgreSQL repository

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -28,6 +28,24 @@ spec:
                 secretKeyRef:
                   name: midpoint-db-app
                   key: password
+            - name: MP_SET_midpoint_repository_database
+              value: postgresql
+            - name: MP_SET_midpoint_repository_jdbcUrl
+              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint
+            - name: MP_SET_midpoint_repository_jdbcUsername
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-db-app
+                  key: username
+            - name: MP_SET_midpoint_repository_jdbcPassword
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-db-app
+                  key: password
+            - name: MP_UNSET_midpoint_repository_hibernateHbm2ddl
+              value: "1"
+            - name: MP_NO_ENV_COMPAT
+              value: "1"
             - name: MP_MEM_INIT
               value: "768M"
             - name: MP_MEM_MAX


### PR DESCRIPTION
## Summary
- override the default midPoint container repository environment so it connects to the CloudNativePG instance
- source the JDBC credentials from the existing midpoint-db-app secret and disable legacy env overrides to keep the Postgres configuration active

## Testing
- ./kustomize build k8s/apps > /tmp/apps.yaml

------
https://chatgpt.com/codex/tasks/task_e_68cc2e144d88832b98ef7240f97d4fb3