### PR TITLE
Fix midPoint CrashLoop by relying on native repository config

### DIFF
--- a/k8s/apps/midpoint/config.xml
+++ b/k8s/apps/midpoint/config.xml
@@ -7,7 +7,7 @@
     <repository>
       <type>native</type>
       <jdbcUrl>jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint</jdbcUrl>
-      <jdbcUsername>midpoint</jdbcUsername>
+      <jdbcUsername>${env.MIDPOINT_DB_USERNAME}</jdbcUsername>
       <jdbcPassword>${env.MIDPOINT_DB_PASSWORD}</jdbcPassword>
     </repository>
     <audit>

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -46,27 +46,16 @@ spec:
                 secretKeyRef:
                   name: midpoint-admin
                   key: password
+            - name: MIDPOINT_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-db-app
+                  key: username
             - name: MIDPOINT_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: midpoint-db-app
                   key: password
-            - name: MP_SET_midpoint_repository_database
-              value: postgresql
-            - name: MP_SET_midpoint_repository_jdbcUrl
-              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint
-            - name: MP_SET_midpoint_repository_jdbcUsername
-              valueFrom:
-                secretKeyRef:
-                  name: midpoint-db-app
-                  key: username
-            - name: MP_SET_midpoint_repository_jdbcPassword
-              valueFrom:
-                secretKeyRef:
-                  name: midpoint-db-app
-                  key: password
-            - name: MP_UNSET_midpoint_repository_hibernateHbm2ddl
-              value: "1"
             - name: MP_NO_ENV_COMPAT
               value: "1"
             - name: MP_MEM_INIT


### PR DESCRIPTION
## Summary
- drop the MP_SET repository overrides so the deployment stops forcing the legacy repository configuration
- expose the CloudNativePG credentials via MIDPOINT_DB_* variables that are consumed directly from config.xml

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc339d754c832b9d3865572fd86306