### PR TITLE
Fix midPoint schema upgrade handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - An init container now copies the default `/opt/midpoint/var` contents from the image into the writable volume used for
     `midpoint.home`. This preserves the bundled keystore and directory structure so the server can start cleanly even when the
     pod is rescheduled onto a fresh node.
+  - midPoint now auto-creates and auto-upgrades its repository schema when it detects a fresh or older database. This prevents
+    CrashLoopBackOff cycles after rerunning the bootstrap workflow against an existing CNPG cluster that already contains a
+    schema from an earlier midPoint release.
 
 
 ### Keycloak realm GitOps notes

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -65,6 +65,10 @@ spec:
                 secretKeyRef:
                   name: midpoint-db-app
                   key: password
+            - name: MP_SET_midpoint_repository_missingSchemaAction
+              value: create
+            - name: MP_SET_midpoint_repository_upgradeableSchemaAction
+              value: upgrade
             - name: MP_UNSET_midpoint_repository_hibernateHbm2ddl
               value: "1"
             - name: MP_NO_ENV_COMPAT


### PR DESCRIPTION
## Summary
- allow the midPoint deployment to auto-create and upgrade its PostgreSQL schema so pods no longer exit when a database already exists
- document in the README that the deployment now performs automatic schema management to avoid CrashLoopBackOffs after rerunning the bootstrap workflow

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc339d754c832b9d3865572fd86306