### PR TITLE
Increase AKS default node capacity

### DIFF
--- a/.github/workflows/01_aks_apply.yml
+++ b/.github/workflows/01_aks_apply.yml
@@ -17,6 +17,15 @@ on:
         description: 'Prefix for resource names'
         required: false
         default: 'rwsdemo'
+      AKS_NODE_VM_SIZE:
+        description: 'VM size for the default AKS node pool'
+        required: false
+        default: 'Standard_D4s_v3'
+      AKS_NODE_COUNT:
+        description: 'Node count for the default AKS node pool'
+        required: false
+        default: 3
+        type: number
 
 permissions:
   id-token: write
@@ -53,7 +62,9 @@ jobs:
         run: |
           terraform plan -input=false \
             -var="location=${{ inputs.LOCATION }}" \
-            -var="prefix=${{ inputs.RESOURCE_PREFIX }}"
+            -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
+            -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \
+            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}"
 
       - name: Terraform Apply
         if: inputs.TF_ACTION == 'apply'
@@ -61,12 +72,19 @@ jobs:
         run: |
           terraform apply -auto-approve -input=false \
             -var="location=${{ inputs.LOCATION }}" \
-            -var="prefix=${{ inputs.RESOURCE_PREFIX }}"
+            -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
+            -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \
+            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}"
 
       - name: Terraform Destroy
         if: inputs.TF_ACTION == 'destroy'
         working-directory: infra/azure/terraform
-        run: terraform destroy -auto-approve -input=false
+        run: |
+          terraform destroy -auto-approve -input=false \
+            -var="location=${{ inputs.LOCATION }}" \
+            -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
+            -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \
+            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}"
 
       - name: Terraform Outputs
         if: inputs.TF_ACTION == 'apply'

--- a/infra/azure/terraform/main.tf
+++ b/infra/azure/terraform/main.tf
@@ -19,14 +19,14 @@ resource "azurerm_resource_group" "rg" {
 
 # Storage account for CNPG backups (Azure Blob)
 resource "azurerm_storage_account" "sa" {
-  name                     = "${var.prefix}sa${random_string.sa_suffix.result}"
-  resource_group_name      = azurerm_resource_group.rg.name
-  location                 = azurerm_resource_group.rg.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  name                            = "${var.prefix}sa${random_string.sa_suffix.result}"
+  resource_group_name             = azurerm_resource_group.rg.name
+  location                        = azurerm_resource_group.rg.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
   allow_nested_items_to_be_public = false
-  min_tls_version          = "TLS1_2"
-  tags                     = local.tags
+  min_tls_version                 = "TLS1_2"
+  tags                            = local.tags
 }
 
 resource "azurerm_storage_container" "cnpg" {
@@ -35,7 +35,7 @@ resource "azurerm_storage_container" "cnpg" {
   container_access_type = "private"
 }
 
-# AKS (small, low-cost defaults)
+# AKS (defaults sized for Keycloak + midPoint demo workloads)
 resource "azurerm_kubernetes_cluster" "aks" {
   name                = "${var.prefix}-aks"
   location            = azurerm_resource_group.rg.location
@@ -44,8 +44,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   default_node_pool {
     name       = "system"
-    vm_size    = "Standard_B2s"
-    node_count = 2
+    vm_size    = var.aks_default_node_vm_size
+    node_count = var.aks_default_node_count
     os_sku     = "AzureLinux"
   }
 
@@ -57,7 +57,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   # workload_identity_enabled = true
 
   network_profile {
-    network_plugin = "azure"
+    network_plugin    = "azure"
     load_balancer_sku = "standard"
   }
 

--- a/infra/azure/terraform/providers.tf
+++ b/infra/azure/terraform/providers.tf
@@ -6,7 +6,7 @@ terraform {
       version = ">= 3.0.0, < 4.0.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = "~> 3.6"
     }
   }

--- a/infra/azure/terraform/terraform.tfvars
+++ b/infra/azure/terraform/terraform.tfvars
@@ -1,3 +1,5 @@
 # You can override these in the GitHub workflow inputs or here
 location = "westeurope"
 prefix   = "rwsdemo"
+# aks_default_node_vm_size = "Standard_D4s_v3"
+# aks_default_node_count   = 3

--- a/infra/azure/terraform/variables.tf
+++ b/infra/azure/terraform/variables.tf
@@ -9,3 +9,15 @@ variable "prefix" {
   description = "Resource prefix (short, lowercase)"
   default     = "rwsdemo"
 }
+
+variable "aks_default_node_vm_size" {
+  type        = string
+  description = "VM size for the default AKS node pool"
+  default     = "Standard_D4s_v3"
+}
+
+variable "aks_default_node_count" {
+  type        = number
+  description = "Number of nodes in the default AKS node pool"
+  default     = 3
+}


### PR DESCRIPTION
## Summary
- size the default AKS node pool for the Keycloak + midPoint workloads and drive the settings from Terraform variables
- expose the node size/count overrides through the provisioning workflow inputs
- document the new defaults and how to tune the node pool sizing

## Testing
- terraform fmt
- terraform init -backend=false *(fails: registry.terraform.io returned HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc39659be8832b9f604f46ec747081