### PR TITLE
Allow Terraform to reuse existing resource group

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 1. Push this repo to GitHub.
 2. Run workflow **`01_aks_apply.yml`** (Actions tab → select workflow → *Run workflow*).
    - Creates: Resource Group, **AKS** (default Standard_D4s_v3 node pool with three nodes), **Storage Account** and a container for CNPG backups.
+     - Reuse an existing Resource Group by setting Terraform variable `create_resource_group=false`. Provide `resource_group_name` if the existing group does not match the default `<prefix>-rg` pattern. The workflow inputs expose the same variables.
    - Override the node pool size/count by supplying the optional workflow inputs `AKS_NODE_VM_SIZE` and `AKS_NODE_COUNT`, or by setting the corresponding Terraform variables.
    - **Heads-up**: Changing either value forces Terraform to replace the default node pool (and usually the cluster), so plan a short outage while the workflow destroys and recreates the nodes.
 3. Once it finishes, the workflow will print outputs and mark success.
@@ -99,7 +100,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 ## Where to change things
 
 - **Terraform vars**: `infra/azure/terraform/terraform.tfvars` (or via repo variables / workflow inputs) – override
-  `location`, `prefix`, `aks_default_node_vm_size`, `aks_default_node_count` as needed.
+  `location`, `prefix`, `create_resource_group`, `resource_group_name`, `aks_default_node_vm_size`, `aks_default_node_count` as needed.
 - **Helm/Argo versions**: see `k8s/addons/*/application.yaml`
 - **DB sizing**: `k8s/apps/cnpg/cluster.yaml`
 

--- a/infra/azure/terraform/outputs.tf
+++ b/infra/azure/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output "resource_group" {
-  value = azurerm_resource_group.rg.name
+  value = local.resource_group_name
 }
 
 output "aks_name" {

--- a/infra/azure/terraform/variables.tf
+++ b/infra/azure/terraform/variables.tf
@@ -10,6 +10,18 @@ variable "prefix" {
   default     = "rwsdemo"
 }
 
+variable "create_resource_group" {
+  type        = bool
+  description = "Whether to create the resource group automatically. Set to false to reuse an existing group."
+  default     = true
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group to create or reuse. Leave empty to default to \"<prefix>-rg\"."
+  default     = ""
+}
+
 variable "aks_default_node_vm_size" {
   type        = string
   description = "VM size for the default AKS node pool"


### PR DESCRIPTION
## Summary
- add configuration that lets Terraform skip creating the Azure resource group and instead target an existing one
- update Azure resources to use shared locals for the group name/location and document the new variables in the README

## Testing
- terraform fmt

------
https://chatgpt.com/codex/tasks/task_e_68cc3b8f17a4832ba62806de7daa9cc2