### PR TITLE
Auto-detect existing resource group in Terraform workflow

### DIFF
--- a/.github/workflows/01_aks_apply.yml
+++ b/.github/workflows/01_aks_apply.yml
@@ -17,6 +17,10 @@ on:
         description: 'Prefix for resource names'
         required: false
         default: 'rwsdemo'
+      RESOURCE_GROUP_NAME:
+        description: 'Resource group to create or reuse (defaults to "<prefix>-rg")'
+        required: false
+        default: ''
       AKS_NODE_VM_SIZE:
         description: 'VM size for the default AKS node pool'
         required: false
@@ -56,35 +60,76 @@ jobs:
         working-directory: infra/azure/terraform
         run: terraform init -input=false
 
+      - name: Determine Resource Group configuration
+        id: rg
+        shell: bash
+        working-directory: infra/azure/terraform
+        env:
+          RESOURCE_PREFIX: ${{ inputs.RESOURCE_PREFIX }}
+          RESOURCE_GROUP_NAME_INPUT: ${{ inputs.RESOURCE_GROUP_NAME }}
+        run: |
+          set -euo pipefail
+          RG_NAME="${RESOURCE_GROUP_NAME_INPUT:-}"
+          if [[ -z "${RG_NAME}" ]]; then
+            RG_NAME="${RESOURCE_PREFIX}-rg"
+          fi
+
+          CREATE_RG="true"
+          if terraform state show azurerm_resource_group.rg[0] >/dev/null 2>&1; then
+            echo "Terraform state already tracks resource group ${RG_NAME}; keeping create_resource_group=true."
+          else
+            if az group exists --name "${RG_NAME}" | grep -qi true; then
+              CREATE_RG="false"
+              echo "Resource group ${RG_NAME} already exists; Terraform will reuse it."
+            else
+              echo "Resource group ${RG_NAME} does not exist; Terraform will create it."
+            fi
+          fi
+
+          echo "resource_group_name=${RG_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "create_resource_group=${CREATE_RG}" >> "${GITHUB_OUTPUT}"
+
       - name: Terraform Plan
         if: inputs.TF_ACTION == 'apply'
         working-directory: infra/azure/terraform
+        shell: bash
         run: |
+          set -euo pipefail
           terraform plan -input=false \
             -var="location=${{ inputs.LOCATION }}" \
             -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
             -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \
-            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}"
+            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}" \
+            -var="resource_group_name=${{ steps.rg.outputs.resource_group_name }}" \
+            -var="create_resource_group=${{ steps.rg.outputs.create_resource_group }}"
 
       - name: Terraform Apply
         if: inputs.TF_ACTION == 'apply'
         working-directory: infra/azure/terraform
+        shell: bash
         run: |
+          set -euo pipefail
           terraform apply -auto-approve -input=false \
             -var="location=${{ inputs.LOCATION }}" \
             -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
             -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \
-            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}"
+            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}" \
+            -var="resource_group_name=${{ steps.rg.outputs.resource_group_name }}" \
+            -var="create_resource_group=${{ steps.rg.outputs.create_resource_group }}"
 
       - name: Terraform Destroy
         if: inputs.TF_ACTION == 'destroy'
         working-directory: infra/azure/terraform
+        shell: bash
         run: |
+          set -euo pipefail
           terraform destroy -auto-approve -input=false \
             -var="location=${{ inputs.LOCATION }}" \
             -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
             -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \
-            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}"
+            -var="aks_default_node_count=${{ inputs.AKS_NODE_COUNT }}" \
+            -var="resource_group_name=${{ steps.rg.outputs.resource_group_name }}" \
+            -var="create_resource_group=${{ steps.rg.outputs.create_resource_group }}"
 
       - name: Terraform Outputs
         if: inputs.TF_ACTION == 'apply'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 1. Push this repo to GitHub.
 2. Run workflow **`01_aks_apply.yml`** (Actions tab → select workflow → *Run workflow*).
    - Creates: Resource Group, **AKS** (default Standard_D4s_v3 node pool with three nodes), **Storage Account** and a container for CNPG backups.
-     - Reuse an existing Resource Group by setting Terraform variable `create_resource_group=false`. Provide `resource_group_name` if the existing group does not match the default `<prefix>-rg` pattern. The workflow inputs expose the same variables.
+     - The workflow auto-detects whether the target resource group already exists. If it does, Terraform reuses it instead of failing. Override the name with the optional `RESOURCE_GROUP_NAME` input when you want to create or reuse a group that does not follow the default `<prefix>-rg` pattern. For local runs you can achieve the same by setting `create_resource_group=false` and `resource_group_name=<name>`.
    - Override the node pool size/count by supplying the optional workflow inputs `AKS_NODE_VM_SIZE` and `AKS_NODE_COUNT`, or by setting the corresponding Terraform variables.
    - **Heads-up**: Changing either value forces Terraform to replace the default node pool (and usually the cluster), so plan a short outage while the workflow destroys and recreates the nodes.
 3. Once it finishes, the workflow will print outputs and mark success.


### PR DESCRIPTION
## Summary
- add a workflow dispatch input for the resource group name and detect whether Terraform should create or reuse it
- pass the detected values into plan/apply/destroy while enforcing bash safety flags in the Terraform job
- document the automatic resource group detection and override option in the README

## Testing
- not run (GitHub Actions workflow changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc3dbd5c9c832bb5fa75f132a79162