### PR TITLE
Set AKS rotation node pool name

### DIFF
--- a/infra/azure/terraform/main.tf
+++ b/infra/azure/terraform/main.tf
@@ -59,6 +59,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
     vm_size    = var.aks_default_node_vm_size
     node_count = var.aks_default_node_count
     os_sku     = "AzureLinux"
+    # Required by the AzureRM provider when properties that force
+    # a rotation (e.g. os_sku) are updated on the default node pool.
+    temporary_name_for_rotation = "systemtmp"
   }
 
   identity {


### PR DESCRIPTION
## Summary
- set a temporary name for AKS default node pool rotation so Terraform can update os_sku and other properties without manual intervention

## Testing
- terraform fmt
- terraform init -backend=false *(fails: access to registry.terraform.io is forbidden in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68cc5e3f78ac832b97ed43f391062995