### PR TITLE
Disable AKS upgrade surge nodes for low quota environments

### DIFF
--- a/infra/azure/terraform/main.tf
+++ b/infra/azure/terraform/main.tf
@@ -62,6 +62,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
     # Required by the AzureRM provider when properties that force
     # a rotation (e.g. os_sku) are updated on the default node pool.
     temporary_name_for_rotation = "systemtmp"
+
+    upgrade_settings {
+      max_surge = var.aks_default_node_max_surge
+    }
   }
 
   identity {

--- a/infra/azure/terraform/terraform.tfvars
+++ b/infra/azure/terraform/terraform.tfvars
@@ -3,3 +3,4 @@ location = "westeurope"
 prefix   = "rwsdemo"
 # aks_default_node_vm_size = "Standard_D4s_v3"
 # aks_default_node_count   = 1
+# aks_default_node_max_surge = "1"

--- a/infra/azure/terraform/variables.tf
+++ b/infra/azure/terraform/variables.tf
@@ -33,3 +33,9 @@ variable "aks_default_node_count" {
   description = "Number of nodes in the default AKS node pool"
   default     = 1
 }
+
+variable "aks_default_node_max_surge" {
+  type        = string
+  description = "Maximum number or percentage of surge nodes to add during upgrades of the default node pool. Use \"0\" to disable surge nodes when regional vCPU quota is tight."
+  default     = "0"
+}


### PR DESCRIPTION
## Summary
- add an upgrade_settings block to the default AKS node pool and expose a variable so surge nodes can be disabled when quota is tight
- default the new variable to "0" and document how to raise it once additional vCPU capacity is available

## Testing
- terraform fmt

------
https://chatgpt.com/codex/tasks/task_e_68cc66a06920832bb6c5e6db82d4aa1d