### PR TITLE
Remove unsupported max_unavailable setting in AKS

### DIFF
--- a/infra/azure/terraform/main.tf
+++ b/infra/azure/terraform/main.tf
@@ -28,7 +28,6 @@ resource "azurerm_resource_group" "rg" {
 locals {
   resource_group_location         = var.create_resource_group ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   aks_default_node_max_surge_trim = trimspace(var.aks_default_node_max_surge)
-  aks_default_node_surge_is_zero  = trimspace(replace(local.aks_default_node_max_surge_trim, "%", "")) == "0"
 }
 
 # Storage account for CNPG backups (Azure Blob)
@@ -67,8 +66,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     temporary_name_for_rotation = "systemtmp"
 
     upgrade_settings {
-      max_surge       = local.aks_default_node_max_surge_trim
-      max_unavailable = local.aks_default_node_surge_is_zero ? "1" : null
+      max_surge = local.aks_default_node_max_surge_trim
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the unsupported `max_unavailable` argument from the AKS default node pool upgrade settings
- drop the unused helper local now that only the trimmed surge value is required

## Testing
- terraform fmt
- terraform init -backend=false *(fails: registry.terraform.io returned 403 while querying providers)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6e9b7e30832b8730cffd6133bb1f