### PR TITLE
Ensure AKS upgrade settings allow downtime budget

### DIFF
--- a/infra/azure/terraform/main.tf
+++ b/infra/azure/terraform/main.tf
@@ -26,8 +26,9 @@ resource "azurerm_resource_group" "rg" {
 }
 
 locals {
-  resource_group_location         = var.create_resource_group ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
-  aks_default_node_max_surge_trim = trimspace(var.aks_default_node_max_surge)
+  resource_group_location          = var.create_resource_group ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
+  aks_default_node_max_surge_trim  = trimspace(var.aks_default_node_max_surge)
+  aks_default_node_max_unavailable = can(regex("^0+%?$", local.aks_default_node_max_surge_trim)) ? "1" : null
 }
 
 # Storage account for CNPG backups (Azure Blob)
@@ -67,6 +68,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
     upgrade_settings {
       max_surge = local.aks_default_node_max_surge_trim
+      # When surge nodes are disabled Azure still requires at least one unavailable node during upgrades.
+      max_unavailable = local.aks_default_node_max_unavailable
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure the AKS default node pool upgrade settings set a fallback `max_unavailable` so rotations no longer fail when surge nodes are disabled

## Testing
- terraform fmt


------
https://chatgpt.com/codex/tasks/task_e_68cc6ffe410c832bb528285fc71a45a2