### PR TITLE
Remove unsupported max_unavailable setting from AKS upgrade configuration

### DIFF
--- a/infra/azure/terraform/main.tf
+++ b/infra/azure/terraform/main.tf
@@ -28,7 +28,6 @@ resource "azurerm_resource_group" "rg" {
 locals {
   resource_group_location          = var.create_resource_group ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   aks_default_node_max_surge_trim  = trimspace(var.aks_default_node_max_surge)
-  aks_default_node_max_unavailable = can(regex("^0+%?$", local.aks_default_node_max_surge_trim)) ? "1" : null
 }
 
 # Storage account for CNPG backups (Azure Blob)
@@ -68,8 +67,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
     upgrade_settings {
       max_surge = local.aks_default_node_max_surge_trim
-      # When surge nodes are disabled Azure still requires at least one unavailable node during upgrades.
-      max_unavailable = local.aks_default_node_max_unavailable
     }
   }
 


### PR DESCRIPTION
## Summary
- drop the unsupported `max_unavailable` setting from the default node pool upgrade configuration so Terraform plans succeed against the current azurerm provider

## Testing
- terraform fmt *(fails: terraform not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc72612db4832ba3644822a8f5eaa0