### PR TITLE
Remove unsupported max_unavailable override for AKS default node pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     - Override `AKS_NODE_VM_SIZE` (workflow input) or `aks_default_node_vm_size` (Terraform variable) if you have quota for a larger SKU such as `Standard_D4s_v3` and want more CPU headroom.
 
     - The control plane defaults to the **AKS Free** tier (`AKS_SKU_TIER` workflow input / `aks_sku_tier` Terraform variable). Leave it on `Free` to avoid uptime SLA charges and because new/free subscriptions often lack the quota required for the paid tier.
-    - The default node pool upgrades with `max_surge=0` so the workflow never needs extra quota for temporary surge nodes. Terraform automatically sets `max_unavailable=1` in that scenario to satisfy the AKS API requirement that at least one upgrade budget is non-zero, which means upgrades briefly cordon the single system node. Expect a short outage while it is replaced; raise `aks_default_node_max_surge` once your subscription has spare vCPU capacity to keep upgrades highly available. You can also tweak `aks_default_node_max_unavailable` (default `1`) if you want AKS to drain more than one node at a time during upgrades.
+    - The default node pool upgrades with `max_surge=0` so the workflow never needs extra quota for temporary surge nodes. AKS automatically keeps `max_unavailable=1` in that scenario to satisfy the API requirement that at least one upgrade budget is non-zero, which means upgrades briefly cordon the single system node. Expect a short outage while it is replaced; raise `aks_default_node_max_surge` once your subscription has spare vCPU capacity so AKS can add surge nodes and keep upgrades highly available.
 
     - After increasing your Azure vCPU quota you can scale the cluster by overriding `AKS_NODE_COUNT` (workflow input) or `aks_default_node_count` (Terraform variable).
     - AKS upgrades that replace the system node pool (for example when switching the OS SKU) briefly request an extra node. Ensure the subscription has enough quota in the chosen VM family to accommodate that surge or request a quota increase before rerunning the workflow.
@@ -109,7 +109,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 ## Where to change things
 
 - **Terraform vars**: `infra/azure/terraform/terraform.tfvars` (or via repo variables / workflow inputs) – override
-  `location`, `prefix`, `create_resource_group`, `resource_group_name`, `aks_default_node_vm_size`, `aks_default_node_count`, `aks_default_node_max_surge`, `aks_default_node_max_unavailable`, `aks_sku_tier` as needed.
+  `location`, `prefix`, `create_resource_group`, `resource_group_name`, `aks_default_node_vm_size`, `aks_default_node_count`, `aks_default_node_max_surge`, `aks_sku_tier` as needed.
 - **Helm/Argo versions**: see `k8s/addons/*/application.yaml`
 - **DB sizing**: `k8s/apps/cnpg/cluster.yaml`
 

--- a/infra/azure/terraform/main.tf
+++ b/infra/azure/terraform/main.tf
@@ -28,7 +28,6 @@ resource "azurerm_resource_group" "rg" {
 locals {
   resource_group_location               = var.create_resource_group ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.rg[0].location
   aks_default_node_max_surge_trim       = trimspace(var.aks_default_node_max_surge)
-  aks_default_node_max_unavailable_trim = trimspace(var.aks_default_node_max_unavailable)
 }
 
 # Storage account for CNPG backups (Azure Blob)
@@ -67,8 +66,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     temporary_name_for_rotation = "systemtmp"
 
     upgrade_settings {
-      max_surge       = local.aks_default_node_max_surge_trim
-      max_unavailable = local.aks_default_node_max_unavailable_trim
+      max_surge = local.aks_default_node_max_surge_trim
     }
   }
 

--- a/infra/azure/terraform/terraform.tfvars
+++ b/infra/azure/terraform/terraform.tfvars
@@ -4,5 +4,4 @@ prefix   = "rwsdemo"
 # aks_default_node_vm_size = "Standard_B2ms"
 # aks_default_node_count   = 1
 # aks_default_node_max_surge = "1"
-# aks_default_node_max_unavailable = "1"
 # aks_sku_tier = "Free" # switch to "Paid" only after confirming the subscription supports the Uptime SLA tier

--- a/infra/azure/terraform/variables.tf
+++ b/infra/azure/terraform/variables.tf
@@ -56,28 +56,12 @@ variable "aks_default_node_count" {
 
 variable "aks_default_node_max_surge" {
   type        = string
-  description = "Maximum number or percentage of surge nodes to add during upgrades of the default node pool. Use \"0\" to disable surge nodes when regional vCPU quota is tight; the module then relies on max_unavailable to keep upgrades moving."
+  description = "Maximum number or percentage of surge nodes to add during upgrades of the default node pool. Use \"0\" to disable surge nodes when regional vCPU quota is tight; AKS will then rotate the single system node sequentially using its default max_unavailable budget."
   default     = "0"
 
   validation {
     condition     = can(regex("^[0-9]+%?$", trimspace(var.aks_default_node_max_surge)))
     error_message = "aks_default_node_max_surge must be an integer (e.g. \"1\") or percentage (e.g. \"33%\"). Use \"0\" to avoid extra surge nodes on constrained subscriptions."
-  }
-}
-
-variable "aks_default_node_max_unavailable" {
-  type        = string
-  description = "Maximum number or percentage of nodes that can be unavailable during upgrades of the default node pool. Must be non-zero whenever surge nodes are disabled."
-  default     = "1"
-
-  validation {
-    condition     = can(regex("^[0-9]+%?$", trimspace(var.aks_default_node_max_unavailable)))
-    error_message = "aks_default_node_max_unavailable must be an integer (e.g. \"1\") or percentage (e.g. \"33%\")."
-  }
-
-  validation {
-    condition     = !(trimspace(var.aks_default_node_max_unavailable) == "0" && trimspace(var.aks_default_node_max_surge) == "0")
-    error_message = "At least one of aks_default_node_max_unavailable or aks_default_node_max_surge must be non-zero to satisfy AKS upgrade requirements."
   }
 }
 


### PR DESCRIPTION
## Summary
- drop the max_unavailable local and property from the AKS default node pool now that the AzureRM provider rejects it
- delete the unused aks_default_node_max_unavailable variable and update docs/tfvars comments to rely on the provider default instead

## Testing
- terraform fmt *(fails: terraform binary not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc75d02280832b83d10b773d1ac598