### PR TITLE
Handle Terraform state lock retries in AKS workflow

### DIFF
--- a/.github/workflows/01_aks_apply.yml
+++ b/.github/workflows/01_aks_apply.yml
@@ -392,7 +392,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          terraform plan -input=false \
+          ./scripts/terraform_with_lock_retry.sh plan -input=false \
             -var="location=${{ inputs.LOCATION }}" \
             -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
             -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \
@@ -407,7 +407,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          terraform apply -auto-approve -input=false \
+          ./scripts/terraform_with_lock_retry.sh apply -auto-approve -input=false \
             -var="location=${{ inputs.LOCATION }}" \
             -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
             -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \
@@ -422,7 +422,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          terraform destroy -auto-approve -input=false \
+          ./scripts/terraform_with_lock_retry.sh destroy -auto-approve -input=false \
             -var="location=${{ inputs.LOCATION }}" \
             -var="prefix=${{ inputs.RESOURCE_PREFIX }}" \
             -var="aks_default_node_vm_size=${{ inputs.AKS_NODE_VM_SIZE }}" \

--- a/infra/azure/terraform/scripts/terraform_with_lock_retry.sh
+++ b/infra/azure/terraform/scripts/terraform_with_lock_retry.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <terraform-subcommand> [args...]" >&2
+  exit 2
+fi
+
+MAX_ATTEMPTS=${TERRAFORM_LOCK_MAX_ATTEMPTS:-5}
+RETRY_BASE_SECONDS=${TERRAFORM_LOCK_RETRY_BASE_SECONDS:-15}
+RETRY_MAX_SECONDS=${TERRAFORM_LOCK_RETRY_MAX_SECONDS:-300}
+
+if ! [[ ${MAX_ATTEMPTS} =~ ^[0-9]+$ ]] || (( MAX_ATTEMPTS < 1 )); then
+  echo "Invalid TERRAFORM_LOCK_MAX_ATTEMPTS value (${MAX_ATTEMPTS}); defaulting to 5." >&2
+  MAX_ATTEMPTS=5
+fi
+
+if ! [[ ${RETRY_BASE_SECONDS} =~ ^[0-9]+$ ]] || (( RETRY_BASE_SECONDS < 1 )); then
+  echo "Invalid TERRAFORM_LOCK_RETRY_BASE_SECONDS value (${RETRY_BASE_SECONDS}); defaulting to 15." >&2
+  RETRY_BASE_SECONDS=15
+fi
+
+if ! [[ ${RETRY_MAX_SECONDS} =~ ^[0-9]+$ ]] || (( RETRY_MAX_SECONDS < 1 )); then
+  echo "Invalid TERRAFORM_LOCK_RETRY_MAX_SECONDS value (${RETRY_MAX_SECONDS}); defaulting to 300." >&2
+  RETRY_MAX_SECONDS=300
+fi
+
+LOCK_PATTERNS=(
+  "Error acquiring the state lock"
+  "state blob is already locked"
+)
+
+attempt=1
+while (( attempt <= MAX_ATTEMPTS )); do
+  echo "--- Terraform attempt ${attempt}/${MAX_ATTEMPTS}: terraform $*"
+  tmp_log=$(mktemp)
+  set +e
+  terraform "$@" 2>&1 | tee "${tmp_log}"
+  exit_code=${PIPESTATUS[0]}
+  set -e
+
+  if (( exit_code == 0 )); then
+    rm -f "${tmp_log}"
+    echo "--- Terraform command completed successfully on attempt ${attempt}."
+    exit 0
+  fi
+
+  if [[ ${attempt} -ge ${MAX_ATTEMPTS} ]]; then
+    echo "Terraform failed after ${attempt} attempts; no retries remaining." >&2
+    rm -f "${tmp_log}"
+    exit ${exit_code}
+  fi
+
+  lock_detected=false
+  for pattern in "${LOCK_PATTERNS[@]}"; do
+    if grep -qi "${pattern}" "${tmp_log}"; then
+      lock_detected=true
+      break
+    fi
+  done
+
+  rm -f "${tmp_log}"
+
+  if [[ ${lock_detected} != true ]]; then
+    echo "Terraform failed with a non-lock error; aborting retries." >&2
+    exit ${exit_code}
+  fi
+
+  wait_seconds=$(( RETRY_BASE_SECONDS * (2 ** (attempt - 1)) ))
+  if (( wait_seconds > RETRY_MAX_SECONDS )); then
+    wait_seconds=${RETRY_MAX_SECONDS}
+  fi
+
+  next_attempt=$(( attempt + 1 ))
+  echo "Terraform state lock detected. Waiting ${wait_seconds}s before retry ${next_attempt}/${MAX_ATTEMPTS}."
+  sleep ${wait_seconds}
+
+  attempt=${next_attempt}
+done
+
+# Should never be reached due to loop exit conditions, but retain fallback for safety.
+echo "Unexpected exit from retry loop." >&2
+exit 1


### PR DESCRIPTION
## Summary
- add a reusable helper that retries Terraform commands when the state lock is busy
- update the AKS provisioning workflow to call the helper for plan/apply/destroy steps

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ccfe4b8484832b8888fbaf0b01690c