### PR TITLE
Add concurrency guard to Terraform workflow

### DIFF
--- a/.github/workflows/01_aks_apply.yml
+++ b/.github/workflows/01_aks_apply.yml
@@ -41,6 +41,10 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: ${{ format('{0}-terraform-{1}', replace(github.repository, '/', '-'), inputs.RESOURCE_PREFIX != '' && inputs.RESOURCE_PREFIX || 'rwsdemo') }}
+  cancel-in-progress: false
+
 jobs:
   terraform:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a concurrency group to the Terraform GitHub Actions workflow so runs for the same prefix queue instead of colliding on the state lock

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd065bb5e4832ba723eb0e3b7d4aba