### PR TITLE
Fix concurrency key without replace function

### DIFF
--- a/.github/workflows/01_aks_apply.yml
+++ b/.github/workflows/01_aks_apply.yml
@@ -42,7 +42,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ format('{0}-terraform-{1}', replace(github.repository, '/', '-'), inputs.RESOURCE_PREFIX != '' && inputs.RESOURCE_PREFIX || 'rwsdemo') }}
+  group: ${{ format('{0}-terraform-{1}', github.repository_id, inputs.RESOURCE_PREFIX != '' && inputs.RESOURCE_PREFIX || 'rwsdemo') }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- update the workflow concurrency group to rely on `github.repository_id` instead of the unsupported `replace` function

## Testing
- not run (workflow update)


------
https://chatgpt.com/codex/tasks/task_e_68cd086ef81c832bba0f5b18098aef3f