### PR TITLE
Fix midPoint repository credentials injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     Adjust these values together with the container `resources` block if you customize the AKS node sizing beyond the defaults.
   - `config.xml` uses the **native PostgreSQL repository** (Sqale) recommended for midPoint 4.9 and later, which
     matches the CloudNativePG PostgreSQL 16 cluster created by the automation.
+  - Repository connection settings are injected at runtime via the `MP_SET_midpoint_repository_*` environment variables in
+    the deployment so the GitOps config can stay credential-free. Update both the manifest and GitHub secrets when changing
+    the database hostname, username or password.
   - An init container now copies the default `/opt/midpoint/var` contents from the image into the writable volume used for
     `midpoint.home`. This preserves the bundled keystore and directory structure so the server can start cleanly even when the
     pod is rescheduled onto a fresh node.

--- a/k8s/apps/midpoint/config.xml
+++ b/k8s/apps/midpoint/config.xml
@@ -6,9 +6,10 @@
     </webApplication>
     <repository>
       <type>native</type>
+      <!-- The deployment overrides these defaults via MP_SET_midpoint_repository_* env vars. -->
       <jdbcUrl>jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint</jdbcUrl>
-      <jdbcUsername>${env.MIDPOINT_DB_USERNAME}</jdbcUsername>
-      <jdbcPassword>${env.MIDPOINT_DB_PASSWORD}</jdbcPassword>
+      <jdbcUsername>midpoint</jdbcUsername>
+      <jdbcPassword>changeit</jdbcPassword>
     </repository>
     <audit>
       <auditService>

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -46,12 +46,16 @@ spec:
                 secretKeyRef:
                   name: midpoint-admin
                   key: password
-            - name: MIDPOINT_DB_USERNAME
+            - name: MP_SET_midpoint_repository_type
+              value: native
+            - name: MP_SET_midpoint_repository_jdbcUrl
+              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint
+            - name: MP_SET_midpoint_repository_jdbcUsername
               valueFrom:
                 secretKeyRef:
                   name: midpoint-db-app
                   key: username
-            - name: MIDPOINT_DB_PASSWORD
+            - name: MP_SET_midpoint_repository_jdbcPassword
               valueFrom:
                 secretKeyRef:
                   name: midpoint-db-app


### PR DESCRIPTION
## Summary
- configure the midPoint deployment to supply repository type, URL, username and password via `MP_SET_midpoint_repository_*` environment variables instead of unused placeholder variables
- restore `config.xml` to static defaults and document the runtime overrides so the GitOps manifests stay credential-free while midPoint receives valid database settings

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd1653e064832b83a92feaa88dc8dd