### PR TITLE
Fix midPoint repository database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - Repository connection settings are injected at runtime via the `MP_SET_midpoint_repository_*` environment variables in
     the deployment so the GitOps config can stay credential-free. Update both the manifest and GitHub secrets when changing
     the database hostname, username or password.
+  - The manifest now explicitly sets `MP_SET_midpoint_repository_database=postgresql` to override the container image's
+    default H2 setting; without it midPoint fails to start because it tries to initialize the embedded H2 repository while
+    pointing at the external PostgreSQL service managed by CloudNativePG.
   - An init container now copies the default `/opt/midpoint/var` contents from the image into the writable volume used for
     `midpoint.home`. This preserves the bundled keystore and directory structure so the server can start cleanly even when the
     pod is rescheduled onto a fresh node.

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -48,6 +48,8 @@ spec:
                   key: password
             - name: MP_SET_midpoint_repository_type
               value: native
+            - name: MP_SET_midpoint_repository_database
+              value: postgresql
             - name: MP_SET_midpoint_repository_jdbcUrl
               value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint
             - name: MP_SET_midpoint_repository_jdbcUsername


### PR DESCRIPTION
## Summary
- ensure the midPoint deployment overrides the container image default and declares the PostgreSQL repository database explicitly
- document the override in the README so operators know why it is required

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd2305e3e4832bafb9fecbc7544562