### PR TITLE
Disable TLS negotiation for MidPoint Postgres connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     Adjust these values together with the container `resources` block if you customize the AKS node sizing beyond the defaults.
   - `config.xml` uses the **native PostgreSQL repository** (Sqale) recommended for midPoint 4.9 and later, which
     matches the CloudNativePG PostgreSQL 16 cluster created by the automation.
+    The JDBC URL explicitly sets `sslmode=disable` because CloudNativePG issues self-signed server certificates by default and
+    the demo deployment does not distribute a CA bundle to midPoint. Without the flag the driver may abort during the TLS
+    handshake and the pod will restart in a crash loop. Disable the flag only after you install a trusted server certificate
+    and update the midPoint keystore accordingly.
   - Repository connection settings are injected at runtime via the `MP_SET_midpoint_repository_*` environment variables in
     the deployment so the GitOps config can stay credential-free. Update both the manifest and GitHub secrets when changing
     the database hostname, username or password.

--- a/k8s/apps/midpoint/config.xml
+++ b/k8s/apps/midpoint/config.xml
@@ -7,7 +7,7 @@
     <repository>
       <type>native</type>
       <!-- The deployment overrides these defaults via MP_SET_midpoint_repository_* env vars. -->
-      <jdbcUrl>jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint</jdbcUrl>
+      <jdbcUrl>jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=disable</jdbcUrl>
       <jdbcUsername>midpoint</jdbcUsername>
       <jdbcPassword>changeit</jdbcPassword>
     </repository>

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: MP_SET_midpoint_repository_database
               value: postgresql
             - name: MP_SET_midpoint_repository_jdbcUrl
-              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint
+              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=disable
             - name: MP_SET_midpoint_repository_jdbcUsername
               valueFrom:
                 secretKeyRef:
@@ -110,7 +110,7 @@ spec:
             - name: MP_SET_midpoint_repository_database
               value: postgresql
             - name: MP_SET_midpoint_repository_jdbcUrl
-              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint
+              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=disable
             - name: MP_SET_midpoint_repository_jdbcUsername
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- append `sslmode=disable` to the MidPoint repository JDBC URL so the pod skips the TLS handshake with CloudNativePG's self-signed certificate
- document in the README why the demo disables SSL and what to do when a trusted certificate is available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd318d0e90832b91eed4ed536aa9b3