### PR TITLE
Fix midPoint ninja run-sql mode casing

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -79,8 +79,8 @@ spec:
 
               if [ "${create_needed}" -eq 1 ]; then
                 echo "Schema not fully initialized; applying create scripts"
-                /opt/midpoint/bin/ninja.sh run-sql --create --mode REPOSITORY
-                /opt/midpoint/bin/ninja.sh run-sql --create --mode AUDIT
+                /opt/midpoint/bin/ninja.sh run-sql --create --mode repository
+                /opt/midpoint/bin/ninja.sh run-sql --create --mode audit
                 upgrade_needed=1
               else
                 echo "midPoint repository schema already initialized"
@@ -88,8 +88,8 @@ spec:
 
               if [ "${upgrade_needed}" -eq 1 ]; then
                 echo "Applying repository upgrade scripts (idempotent)"
-                /opt/midpoint/bin/ninja.sh run-sql --upgrade --mode REPOSITORY
-                /opt/midpoint/bin/ninja.sh run-sql --upgrade --mode AUDIT
+                /opt/midpoint/bin/ninja.sh run-sql --upgrade --mode repository
+                /opt/midpoint/bin/ninja.sh run-sql --upgrade --mode audit
               else
                 echo "midPoint repository schema already at latest version"
               fi


### PR DESCRIPTION
## Summary
- fix the `ninja.sh run-sql` invocations in the midPoint init container to use the lowercase repository/audit mode names expected by the CLI

## Testing
- not run (YAML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd35bde61c832bac35e4e663d962a9