### PR TITLE
Ensure midPoint schema init uses bundled PostgreSQL driver

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -42,12 +42,22 @@ spec:
             - |
               set -euo pipefail
 
+              echo "Locating PostgreSQL JDBC driver"
+              postgres_driver="$(find /opt/midpoint/lib -maxdepth 1 -type f -name 'postgresql-*.jar' | sort | tail -n 1)"
+
+              if [ -z "${postgres_driver}" ]; then
+                echo "ERROR: Could not find a PostgreSQL JDBC driver under /opt/midpoint/lib" >&2
+                exit 1
+              fi
+
+              echo "Using JDBC driver: ${postgres_driver}"
+
               echo "Initializing midPoint native repository assets"
               /opt/midpoint/bin/midpoint.sh init-native
 
               echo "Inspecting current repository schema state"
               info_log="/tmp/ninja-info.log"
-              if /opt/midpoint/bin/ninja.sh -B info >"${info_log}" 2>&1; then
+              if /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" -B info >"${info_log}" 2>&1; then
                 ninja_status=0
               else
                 ninja_status=$?
@@ -79,8 +89,8 @@ spec:
 
               if [ "${create_needed}" -eq 1 ]; then
                 echo "Schema not fully initialized; applying create scripts"
-                /opt/midpoint/bin/ninja.sh run-sql --create --mode REPOSITORY
-                /opt/midpoint/bin/ninja.sh run-sql --create --mode AUDIT
+                /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" run-sql --create --mode REPOSITORY
+                /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" run-sql --create --mode AUDIT
                 upgrade_needed=1
               else
                 echo "midPoint repository schema already initialized"
@@ -88,8 +98,8 @@ spec:
 
               if [ "${upgrade_needed}" -eq 1 ]; then
                 echo "Applying repository upgrade scripts (idempotent)"
-                /opt/midpoint/bin/ninja.sh run-sql --upgrade --mode REPOSITORY
-                /opt/midpoint/bin/ninja.sh run-sql --upgrade --mode AUDIT
+                /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" run-sql --upgrade --mode REPOSITORY
+                /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" run-sql --upgrade --mode AUDIT
               else
                 echo "midPoint repository schema already at latest version"
               fi


### PR DESCRIPTION
## Summary
- detect the PostgreSQL JDBC driver inside the midPoint image before running ninja
- pass the driver path to every ninja invocation so schema create and upgrade succeed
- fail fast with a clear error if the driver jar is unexpectedly missing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd35bde61c832bac35e4e663d962a9