### PR TITLE
Ensure midPoint automation uses compatible shells

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: midpoint-db-init
           image: evolveum/midpoint:4.9
           command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
               set -euo pipefail

--- a/k8s/apps/midpoint/seeder-job.yaml
+++ b/k8s/apps/midpoint/seeder-job.yaml
@@ -22,10 +22,10 @@ spec:
             - name: objs
               mountPath: /objects
           command:
-            - sh
-            - -lc
+            - /bin/sh
+            - -ec
             - |
-              set -euo pipefail
+              set -eu
               MP_URL="${MIDPOINT_URL:-http://midpoint:8080/midpoint}"
               echo "Using midPoint at: $MP_URL"
 


### PR DESCRIPTION
## Summary
- run the midPoint database init container script under Bash so the `pipefail` option is honored
- execute the midPoint seeder job with `/bin/sh -ec` and POSIX flags to avoid unsupported `pipefail`

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd43e8e170832baa2e4735bab04c3c