### PR TITLE
Ensure ninja run-sql uses PostgreSQL driver

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -90,8 +90,8 @@ spec:
               if [ "${create_needed}" -eq 1 ]; then
                 echo "Schema not fully initialized; applying create scripts"
                 
-                /opt/midpoint/bin/ninja.sh run-sql --create --mode repository
-                /opt/midpoint/bin/ninja.sh run-sql --create --mode audit
+                /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" run-sql --create --mode repository
+                /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" run-sql --create --mode audit
 
                 upgrade_needed=1
               else
@@ -101,8 +101,8 @@ spec:
               if [ "${upgrade_needed}" -eq 1 ]; then
                 echo "Applying repository upgrade scripts (idempotent)"
 
-                /opt/midpoint/bin/ninja.sh run-sql --upgrade --mode repository
-                /opt/midpoint/bin/ninja.sh run-sql --upgrade --mode audit
+                /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" run-sql --upgrade --mode repository
+                /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" run-sql --upgrade --mode audit
 
               else
                 echo "midPoint repository schema already at latest version"


### PR DESCRIPTION
## Summary
- ensure the midPoint bootstrap init container passes the PostgreSQL JDBC driver to every ninja run-sql invocation so repository create/upgrade scripts can talk to the database reliably

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd43e8e170832baa2e4735bab04c3c