### PR TITLE
Fix Keycloak realm webauthn fields

### DIFF
--- a/k8s/apps/keycloak/rws-realm.yaml
+++ b/k8s/apps/keycloak/rws-realm.yaml
@@ -13,11 +13,10 @@ spec:
     loginWithEmailAllowed: true
     resetPasswordAllowed: true
     sslRequired: none
-    webAuthnPolicy:
-      rpEntityName: "RWS Demo"
-      userVerificationRequirement: "required"
-      createTimeout: 120000
-      avoidSameAuthenticatorRegister: true
+    webAuthnPolicyRpEntityName: "RWS Demo"
+    webAuthnPolicyUserVerificationRequirement: "required"
+    webAuthnPolicyCreateTimeout: 120000
+    webAuthnPolicyAvoidSameAuthenticatorRegister: true
     clients:
       - clientId: rws-midpoint
         name: rws-midpoint


### PR DESCRIPTION
## Summary
- align the Keycloak realm patch with the flat webAuthn policy field names expected by Keycloak so the import succeeds

## Testing
- not run (YAML change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd43e8e170832baa2e4735bab04c3c