### PR TITLE
Fix midPoint init retry and improve diagnostics

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1583,6 +1583,48 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          dump_init_container_logs() {
+            local target_ns="$1"
+
+            if [ -z "${target_ns}" ]; then
+              return 0
+            fi
+
+            local pods_json
+            if ! pods_json=$(kubectl -n "${target_ns}" get pods -o json 2>/dev/null); then
+              echo "WARNING: Unable to retrieve pod details for namespace ${target_ns}" >&2
+              return 0
+            fi
+
+            local failing_pairs
+            failing_pairs="$(
+              jq -r '
+                .items[]? as $pod
+                | ($pod.status.initContainerStatuses // [])[]
+                | ( .state.waiting.reason // "" ) as $waiting_reason
+                | ( .state.terminated // {} ) as $term
+                | ( .lastState.terminated // {} ) as $last_term
+                | select(
+                    ($waiting_reason != "" and ($waiting_reason | test("^(CrashLoopBackOff|ErrImagePull|ImagePullBackOff|CreateContainerConfigError|Error)$")))
+                    or (($term.exitCode // 0) != 0)
+                    or (($last_term.exitCode // 0) != 0)
+                  )
+                | "\($pod.metadata.name)\t\(.name)"
+              ' <<<"${pods_json}"
+            )"
+
+            if [ -z "${failing_pairs}" ]; then
+              echo "No failing init containers detected in namespace ${target_ns}."
+              return 0
+            fi
+
+            echo "Collecting init container logs in namespace ${target_ns}:"
+            while IFS=$'\t' read -r pod_name init_name; do
+              [ -z "${pod_name}" ] && continue
+              echo "---- Logs for init container ${init_name} in pod ${target_ns}/${pod_name} ----"
+              kubectl -n "${target_ns}" logs "${pod_name}" -c "${init_name}" --tail=200 || true
+            done <<<"${failing_pairs}"
+          }
           echo "Ensuring Argo CD application 'apps' has been created before monitoring status"
           app_found=0
           for attempt in $(seq 1 60); do
@@ -1760,6 +1802,7 @@ jobs:
                 kubectl -n "${apps_namespace}" get pods -o wide || true
                 echo "Recent events in namespace ${apps_namespace}:"
                 kubectl -n "${apps_namespace}" get events --sort-by=.metadata.creationTimestamp | tail -n 50 || true
+                dump_init_container_logs "${apps_namespace}"
               fi
 
               diagnostics_dumped=1
@@ -1775,6 +1818,7 @@ jobs:
             kubectl -n "${apps_namespace}" get pods -o wide || true
             echo "Recent events in namespace ${apps_namespace}:"
             kubectl -n "${apps_namespace}" get events --sort-by=.metadata.creationTimestamp | tail -n 50 || true
+            dump_init_container_logs "${apps_namespace}"
           fi
           exit 1
 

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -109,6 +109,25 @@ spec:
                 return "${status}"
               }
 
+              run_midpoint_init_native() {
+                local log_file
+                log_file="$(mktemp)"
+
+                if MP_SET_midpoint_repository_jdbcUsername="${db_username}" \
+                   MP_SET_midpoint_repository_jdbcPassword="${db_password}" \
+                   /opt/midpoint/bin/midpoint.sh init-native >"${log_file}" 2>&1; then
+                  echo "midpoint.sh init-native completed successfully"
+                  rm -f "${log_file}"
+                  return 0
+                fi
+
+                local status=$?
+                echo "WARNING: midpoint.sh init-native failed with exit code ${status}" >&2
+                mask_file_output "${log_file}" >&2 || cat "${log_file}" >&2
+                rm -f "${log_file}"
+                return "${status}"
+              }
+
               config_template="/config-template/config.xml"
               config_target="/opt/midpoint/var/config.xml"
 
@@ -158,7 +177,9 @@ spec:
               echo "Using JDBC driver: ${postgres_driver}"
 
               echo "Initializing midPoint native repository assets"
-              /opt/midpoint/bin/midpoint.sh init-native
+              if ! run_midpoint_init_native; then
+                echo "Continuing with ninja-based schema inspection despite init-native failure" >&2
+              fi
 
               echo "Inspecting current repository schema state"
               info_log="/tmp/ninja-info.log"


### PR DESCRIPTION
## Summary
- wrap midpoint.sh init-native in the midPoint init container so it runs with the rendered credentials, masks its output on failure, and allows ninja-based schema checks to continue
- add an init container log harvester to the Argo CD monitoring step so GitHub Actions dumps failing init logs when the application degrades or times out

## Testing
- `kustomize build k8s/apps` *(fails: kustomize not installed in runner image)*

------
https://chatgpt.com/codex/tasks/task_e_68cd69b17f50832b84d11845a84f5711