### PR TITLE
Fix midPoint schema check

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -245,7 +245,7 @@ spec:
 
               echo "Inspecting current repository schema state"
               info_log="$(mktemp)"
-              if run_ninja_command "${info_log}" "info" -B info; then
+              if run_ninja_command "${info_log}" "info" info; then
                 ninja_status=0
               else
                 ninja_status=$?
@@ -272,6 +272,7 @@ spec:
 
               if [ "${ninja_status}" -ne 0 ]; then
                 echo "ninja info command exited with status ${ninja_status}"
+                create_needed=1
                 upgrade_needed=1
               fi
 


### PR DESCRIPTION
## Summary
- call the midPoint ninja `info` command correctly during the init container bootstrap
- force a schema create attempt when the info probe fails so the upgrade step no longer dies on empty databases

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd7c670edc832b8b43aa1c66872724