### PR TITLE
Fix midPoint schema check

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -117,7 +117,7 @@ spec:
                 local status=0
 
                 while [ "${attempt}" -le "${ninja_max_attempts}" ]; do
-                  if /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" "$@" >"${log_file}" 2>&1; then
+                  if /opt/midpoint/bin/ninja.sh -j "${postgres_driver}" -m "${midpoint_home}" "$@" >"${log_file}" 2>&1; then
                     echo "ninja ${label} completed successfully (attempt ${attempt}/${ninja_max_attempts})"
                     return 0
                   fi
@@ -190,8 +190,17 @@ spec:
                 return "${status}"
               }
 
+              midpoint_home="${MIDPOINT_HOME:-/opt/midpoint/var}"
+
+              if [ ! -d "${midpoint_home}" ]; then
+                echo "ERROR: midPoint home directory ${midpoint_home} not found" >&2
+                exit 1
+              fi
+
+              export MIDPOINT_HOME="${midpoint_home}"
+
               config_template="/config-template/config.xml"
-              config_target="/opt/midpoint/var/config.xml"
+              config_target="${midpoint_home}/config.xml"
 
               echo "Rendering midPoint configuration with repository connection settings"
               if [ ! -f "${config_template}" ]; then
@@ -245,7 +254,7 @@ spec:
 
               echo "Inspecting current repository schema state"
               info_log="$(mktemp)"
-              if run_ninja_command "${info_log}" "info" -B info; then
+              if run_ninja_command "${info_log}" "info" info; then
                 ninja_status=0
               else
                 ninja_status=$?
@@ -272,6 +281,7 @@ spec:
 
               if [ "${ninja_status}" -ne 0 ]; then
                 echo "ninja info command exited with status ${ninja_status}"
+                create_needed=1
                 upgrade_needed=1
               fi
 


### PR DESCRIPTION
## Summary
- call the midPoint ninja `info` command correctly during the init container bootstrap
- force a schema create attempt when the info probe fails so the upgrade step no longer dies on empty databases
- explicitly set the midPoint home directory and hand it to `ninja.sh` so the CLI finds the rendered `config.xml`

## Testing
- not run (kubectl unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd7c670edc832b8b43aa1c66872724