### PR TITLE
Ensure midpoint config.xml ownership matches runtime user

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -225,8 +225,14 @@ spec:
                 exit 1
               fi
 
+              midpoint_home="/opt/midpoint/var"
+              midpoint_uid="$(stat -c '%u' "${midpoint_home}" 2>/dev/null || echo 0)"
+              midpoint_gid="$(stat -c '%g' "${midpoint_home}" 2>/dev/null || echo 0)"
+
+              echo "Setting ownership of config.xml to ${midpoint_uid}:${midpoint_gid}"
+
               chmod 600 "${tmp_config}"
-              chown "$(id -u)":"$(id -g)" "${tmp_config}"
+              chown "${midpoint_uid}:${midpoint_gid}" "${tmp_config}"
               mv "${tmp_config}" "${config_target}"
 
               echo "Rendered config.xml with repository credentials"


### PR DESCRIPTION
## Summary
- detect the uid and gid expected for the midPoint home directory during the midpoint-db-init step
- apply that ownership to the rendered config.xml so the runtime container can read it safely
- add logging to clarify which ownership is configured

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd86fe4958832bb461de9619dd8974