### PR TITLE
Fix midpoint DB init working directory

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -36,11 +36,14 @@ spec:
               mountPath: /midpoint-home
         - name: midpoint-db-init
           image: evolveum/midpoint:4.9
+          workingDir: /opt/midpoint
           command:
             - /bin/bash
             - -c
             - |
               set -euo pipefail
+
+              cd /opt/midpoint
 
               ninja_cmd_base=(/opt/midpoint/bin/ninja.sh)
 


### PR DESCRIPTION
## Summary
- ensure the midpoint-db-init init container runs from /opt/midpoint so ninja.sh can locate its SQL scripts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd86fe4958832bb461de9619dd8974