### PR TITLE
Fix midPoint repository bootstrap to read secrets from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     the demo deployment does not distribute a CA bundle to midPoint. Without the flag the driver may abort during the TLS
     handshake and the pod will restart in a crash loop. Disable the flag only after you install a trusted server certificate
     and update the midPoint keystore accordingly.
-  - Repository connection settings are injected at runtime via the `MP_SET_midpoint_repository_*` environment variables in
-    the deployment so the GitOps config can stay credential-free. Update both the manifest and GitHub secrets when changing
-    the database hostname, username or password.
+  - The `midpoint-db-init` container renders `config.xml` from a template using the database credentials mounted as files.
+    This keeps the GitOps manifests credential-free while ensuring the running pod always picks up the latest JDBC settings.
+    Update both the manifest (for the JDBC URL or secret paths) and the GitHub secrets when changing the database hostname,
+    username or password.
   - An init container now runs `midpoint.sh init-native` and then drives `ninja.sh run-sql` to create **and upgrade** the
     PostgreSQL schema before the main pod starts. The workflow is idempotent, so it safely bootstraps fresh clusters and also
     applies in-place upgrades when you bump the midPoint image version. The helper retries `midpoint.sh` and every `ninja`
@@ -140,12 +141,11 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - An init container now copies the default `/opt/midpoint/var` contents from the image into the writable volume used for
     `midpoint.home`. This preserves the bundled keystore and directory structure so the server can start cleanly even when the
     pod is rescheduled onto a fresh node.
-  - Secrets are mounted as files and consumed via the `_FILE` environment variable variants to avoid shell re-interpretation of
-    special characters (notably `$`) inside database or administrator passwords. Without this, the `midpoint-db-init` init
-    container kept crashing during the `ninja` schema commands because Bash expanded characters such as `$$` to the process ID,
-    causing authentication failures. The updated init script now reads the credentials from those files, substitutes them into
-    `config.xml`, and invokes `ninja` directly with enhanced error logging so failed runs surface the sanitized command output
-    instead of leaving operators to guess at the root cause.
+  - Secrets are mounted as files so the init script can read the literal credential values without exposing them to shell
+    expansion. Without this, the `midpoint-db-init` init container kept crashing during the `ninja` schema commands because Bash
+    expanded characters such as `$$` to the process ID, causing authentication failures. The updated helper reads the
+    credentials directly from the mounted files, substitutes them into `config.xml`, and invokes `ninja` with enhanced error
+    logging so failed runs surface the sanitized command output instead of leaving operators to guess at the root cause.
 
 ### Troubleshooting: midPoint init container crash loops
 
@@ -157,12 +157,11 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   evaluates those variables via `eval`, so Bash expanded `$` sequences (for example, `$$` became the PID). The altered password
   then failed PostgreSQL authentication, aborting the schema check/upgrade with a non-zero exit code and re-triggering the init
   container.
-- **Permanent fix**: Secrets are now mounted as volumes and referenced via the `_FILE` variants of the `MP_SET_*` variables,
-  and the init container reads the credential files directly before calling `ninja` (see `k8s/apps/midpoint/deployment.yaml`).
-  This removes the double-parsing pitfall and lets midPoint use the literal secret values. The helper also masks sensitive data
-  in the captured logs so operators still get actionable diagnostics when a different error occurs. It now retries
-  `midpoint.sh init-native` and the `ninja` schema commands before giving up so a short database failover no longer bricks the
-  deployment.
+- **Permanent fix**: Secrets are now mounted as volumes and read directly from their files before the init container calls
+  `ninja` (see `k8s/apps/midpoint/deployment.yaml`). This removes the double-parsing pitfall and lets midPoint use the literal
+  secret values. The helper also masks sensitive data in the captured logs so operators still get actionable diagnostics when a
+  different error occurs. It now retries `midpoint.sh init-native` and the `ninja` schema commands before giving up so a short
+  database failover no longer bricks the deployment.
 
 - **Diagnostics**: When the Argo CD `apps` application reports a degraded pod, the bootstrap workflow now dumps the `describe`
   output plus the last and previous log snippets for every init and app container. This makes the failing init container output

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -69,31 +69,21 @@ spec:
                 mask_file_output "${file_path}" || cat "${file_path}"
               }
 
-              read_secret_value() {
-                local value_var="$1"
-                local file_var="$2"
-                local description="$3"
+              read_secret_file() {
+                local file_path="$1"
+                local description="$2"
 
-                local value="${!value_var-}"
-                local file_path="${!file_var-}"
-
-                if [ -n "${value}" ]; then
-                  printf '%s' "${value}"
-                  return 0
+                if [ -z "${file_path}" ]; then
+                  echo "ERROR: ${description} file path is empty" >&2
+                  return 1
                 fi
 
-                if [ -n "${file_path}" ]; then
-                  if [ ! -r "${file_path}" ]; then
-                    echo "ERROR: ${description} file ${file_path} is not readable" >&2
-                    return 1
-                  fi
-
-                  cat "${file_path}"
-                  return 0
+                if [ ! -r "${file_path}" ]; then
+                  echo "ERROR: ${description} file ${file_path} is not readable" >&2
+                  return 1
                 fi
 
-                echo "ERROR: ${description} not provided via \$${value_var} or \$${file_var}" >&2
-                return 1
+                cat "${file_path}"
               }
 
               parse_positive_int() {
@@ -106,6 +96,18 @@ spec:
                   printf '%s' "${fallback}"
                 fi
               }
+
+              jdbc_url="${MIDPOINT_JDBC_URL:-}"
+              if [ -z "${jdbc_url}" ]; then
+                echo "ERROR: Repository JDBC URL is empty" >&2
+                exit 1
+              fi
+
+              db_username_file="${MIDPOINT_DB_USERNAME_FILE:-/var/run/secrets/midpoint-db-app/username}"
+              db_password_file="${MIDPOINT_DB_PASSWORD_FILE:-/var/run/secrets/midpoint-db-app/password}"
+
+              db_username="$(read_secret_file "${db_username_file}" 'repository username')"
+              db_password="$(read_secret_file "${db_password_file}" 'repository password')"
 
               ninja_max_attempts="$(parse_positive_int "${MP_NINJA_MAX_ATTEMPTS:-5}" 5)"
               ninja_retry_delay_seconds="$(parse_positive_int "${MP_NINJA_RETRY_DELAY_SECONDS:-5}" 5)"
@@ -201,15 +203,6 @@ spec:
                 exit 1
               fi
 
-              jdbc_url="${MP_SET_midpoint_repository_jdbcUrl:-}"
-              if [ -z "${jdbc_url}" ]; then
-                echo "ERROR: Repository JDBC URL is empty" >&2
-                exit 1
-              fi
-
-              db_username="$(read_secret_value MP_SET_midpoint_repository_jdbcUsername MP_SET_midpoint_repository_jdbcUsername_FILE 'repository username')"
-              db_password="$(read_secret_value MP_SET_midpoint_repository_jdbcPassword MP_SET_midpoint_repository_jdbcPassword_FILE 'repository password')"
-
               tmp_config="$(mktemp)"
               cp "${config_template}" "${tmp_config}"
 
@@ -303,15 +296,11 @@ spec:
 
               echo "midPoint repository bootstrap complete"
           env:
-            - name: MP_SET_midpoint_repository_type
-              value: native
-            - name: MP_SET_midpoint_repository_database
-              value: postgresql
-            - name: MP_SET_midpoint_repository_jdbcUrl
+            - name: MIDPOINT_JDBC_URL
               value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=disable
-            - name: MP_SET_midpoint_repository_jdbcUsername_FILE
+            - name: MIDPOINT_DB_USERNAME_FILE
               value: /var/run/secrets/midpoint-db-app/username
-            - name: MP_SET_midpoint_repository_jdbcPassword_FILE
+            - name: MIDPOINT_DB_PASSWORD_FILE
               value: /var/run/secrets/midpoint-db-app/password
             - name: MP_NO_ENV_COMPAT
               value: "1"
@@ -333,18 +322,6 @@ spec:
           env:
             - name: MP_SET_midpoint_administrator_initialPassword_FILE
               value: /var/run/secrets/midpoint-admin/password
-            - name: MP_SET_midpoint_repository_type
-              value: native
-            - name: MP_SET_midpoint_repository_database
-              value: postgresql
-            - name: MP_SET_midpoint_repository_jdbcUrl
-              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=disable
-            - name: MP_SET_midpoint_repository_jdbcUsername_FILE
-              value: /var/run/secrets/midpoint-db-app/username
-            - name: MP_SET_midpoint_repository_jdbcPassword_FILE
-              value: /var/run/secrets/midpoint-db-app/password
-            - name: MP_SET_midpoint_repository_database
-              value: postgresql
             - name: MP_NO_ENV_COMPAT
               value: "1"
             - name: MP_MEM_INIT
@@ -354,9 +331,6 @@ spec:
           volumeMounts:
             - name: midpoint-home
               mountPath: /opt/midpoint/var
-            - name: midpoint-db-credentials
-              mountPath: /var/run/secrets/midpoint-db-app
-              readOnly: true
             - name: midpoint-admin-secret
               mountPath: /var/run/secrets/midpoint-admin
               readOnly: true


### PR DESCRIPTION
## Summary
- render the midPoint JDBC credentials from the mounted secret files inside the init container
- stop propagating MP_SET repository environment variables to the runtime pod and rely on the rendered config
- document the updated bootstrap flow in the README

## Testing
- not run (kustomize binary is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd86fe4958832bb461de9619dd8974