### PR TITLE
Fix midPoint config ownership detection

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -222,8 +222,30 @@ spec:
               fi
 
               midpoint_home="/opt/midpoint/var"
-              midpoint_uid="$(stat -c '%u' "${midpoint_home}" 2>/dev/null || echo 0)"
-              midpoint_gid="$(stat -c '%g' "${midpoint_home}" 2>/dev/null || echo 0)"
+
+              resolve_midpoint_owner() {
+                local candidate_uid
+                local candidate_gid
+
+                if candidate_uid="$(id -u midpoint 2>/dev/null)" && \
+                   candidate_gid="$(id -g midpoint 2>/dev/null)"; then
+                  midpoint_uid="${candidate_uid}"
+                  midpoint_gid="${candidate_gid}"
+                  return 0
+                fi
+
+                if candidate_uid="$(stat -c '%u' "${midpoint_home}" 2>/dev/null)" && \
+                   candidate_gid="$(stat -c '%g' "${midpoint_home}" 2>/dev/null)"; then
+                  midpoint_uid="${candidate_uid}"
+                  midpoint_gid="${candidate_gid}"
+                  return 0
+                fi
+
+                midpoint_uid=0
+                midpoint_gid=0
+              }
+
+              resolve_midpoint_owner
 
               echo "Setting ownership of config.xml to ${midpoint_uid}:${midpoint_gid}"
 


### PR DESCRIPTION
## Summary
- ensure the midpoint-db-init helper chowns config.xml to the midpoint user when present so the app container can read it

## Testing
- not run (kustomize binary not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd91f15f50832bbed0e8095568b7ed