### PR TITLE
Unset default H2 repository env for midPoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     the demo deployment does not distribute a CA bundle to midPoint. Without the flag the driver may abort during the TLS
     handshake and the pod will restart in a crash loop. Disable the flag only after you install a trusted server certificate
     and update the midPoint keystore accordingly.
+    The deployment now clears the container image's default `MP_SET_midpoint_repository_*` environment variables so the
+    rendered `config.xml` remains authoritative for repository settings instead of reverting to the bundled H2 defaults.
   - The `midpoint-db-init` container renders `config.xml` from a template using the database credentials mounted as files.
     This keeps the GitOps manifests credential-free while ensuring the running pod always picks up the latest JDBC settings.
     Update both the manifest (for the JDBC URL or secret paths) and the GitHub secrets when changing the database hostname,

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -335,6 +335,18 @@ spec:
               value: /var/run/secrets/midpoint-db-app/password
             - name: MP_NO_ENV_COMPAT
               value: "1"
+            - name: MP_UNSET_midpoint_repository_database
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_jdbcUrl
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_hibernateHbm2ddl
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_initializationFailTimeout
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_missingSchemaAction
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_upgradeableSchemaAction
+              value: "1"
           volumeMounts:
             - name: midpoint-home
               mountPath: /opt/midpoint/var
@@ -359,6 +371,18 @@ spec:
               value: "768M"
             - name: MP_MEM_MAX
               value: "1536M"
+            - name: MP_UNSET_midpoint_repository_database
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_jdbcUrl
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_hibernateHbm2ddl
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_initializationFailTimeout
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_missingSchemaAction
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_upgradeableSchemaAction
+              value: "1"
           volumeMounts:
             - name: midpoint-home
               mountPath: /opt/midpoint/var


### PR DESCRIPTION
## Summary
- clear the midPoint init and runtime containers of the image's default `MP_SET_midpoint_repository_*` values so the rendered configuration drives the JDBC settings
- document in the README that the deployment now removes the bundled H2 defaults from the environment

## Testing
- not run (not required for this change)


------
https://chatgpt.com/codex/tasks/task_e_68cd98d26da0832bbcbd20cff001a2fd