### PR TITLE
Fix midPoint JDBC credentials override

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     the demo deployment does not distribute a CA bundle to midPoint. Without the flag the driver may abort during the TLS
     handshake and the pod will restart in a crash loop. Disable the flag only after you install a trusted server certificate
     and update the midPoint keystore accordingly.
-    The deployment now clears the container image's default `MP_SET_midpoint_repository_*` environment variables so the
-    rendered `config.xml` remains authoritative for repository settings instead of reverting to the bundled H2 defaults.
+    The deployment now clears the container image's default `MP_SET_midpoint_repository_*` environment variables (including
+    the JDBC URL and credentials) so the rendered `config.xml` remains authoritative for repository settings instead of
+    reverting to the bundled H2 defaults or the sample `midpoint/midpoint` password.
   - The `midpoint-db-init` container renders `config.xml` from a template using the database credentials mounted as files.
     This keeps the GitOps manifests credential-free while ensuring the running pod always picks up the latest JDBC settings.
     Update both the manifest (for the JDBC URL or secret paths) and the GitHub secrets when changing the database hostname,

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -379,6 +379,14 @@ spec:
               value: "1"
             - name: MP_UNSET_midpoint_repository_upgradeableSchemaAction
               value: "1"
+            - name: MP_UNSET_midpoint_repository_jdbcUsername
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_jdbcPassword
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_username
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_password
+              value: "1"
           volumeMounts:
             - name: midpoint-home
               mountPath: /opt/midpoint/var
@@ -414,6 +422,14 @@ spec:
             - name: MP_UNSET_midpoint_repository_missingSchemaAction
               value: "1"
             - name: MP_UNSET_midpoint_repository_upgradeableSchemaAction
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_jdbcUsername
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_jdbcPassword
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_username
+              value: "1"
+            - name: MP_UNSET_midpoint_repository_password
               value: "1"
           volumeMounts:
             - name: midpoint-home


### PR DESCRIPTION
## Summary
- clear the container image defaults for midPoint JDBC username/password so the rendered config.xml remains authoritative
- document that repository credentials are now un-set to prevent fallback to the sample midpoint/midpoint password

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd9c5bff0c832ba8e6f34220dc0332