### PR TITLE
Fix midPoint config.xml ownership in init container

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -283,7 +283,16 @@ spec:
 
               chmod 600 "${tmp_config}"
               chown "${midpoint_uid}:${midpoint_gid}" "${tmp_config}"
-              mv "${tmp_config}" "${config_target}"
+
+              if ! mv "${tmp_config}" "${config_target}"; then
+                status=$?
+                echo "ERROR: Failed to install rendered config.xml (mv exited with ${status})" >&2
+                rm -f "${tmp_config}" || true
+                exit "${status}"
+              fi
+
+              chmod 600 "${config_target}"
+              chown "${midpoint_uid}:${midpoint_gid}" "${config_target}"
 
               echo "Rendered config.xml with repository credentials"
 


### PR DESCRIPTION
## Summary
- guard the midPoint init helper against mv failures when installing config.xml
- reset ownership and permissions on the final config.xml so the midpoint user can read it

## Testing
- kustomize build k8s/apps/midpoint *(fails: kustomize is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9c5bff0c832ba8e6f34220dc0332