### PR TITLE
Escape XML when rendering midPoint JDBC config

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - The `midpoint-db-init` container renders `config.xml` from a template using the database credentials mounted as files.
     This keeps the GitOps manifests credential-free while ensuring the running pod always picks up the latest JDBC settings.
     Update both the manifest (for the JDBC URL or secret paths) and the GitHub secrets when changing the database hostname,
-    username or password.
+    username or password. The helper now also escapes XML entities so passwords containing characters such as `&` or `<`
+    no longer corrupt the rendered configuration.
   - An init container now runs `midpoint.sh init-native` and then drives `ninja.sh run-sql` to create **and upgrade** the
     PostgreSQL schema before the main pod starts. The workflow is idempotent, so it safely bootstraps fresh clusters and also
     applies in-place upgrades when you bump the midPoint image version. The helper retries `midpoint.sh` and every `ninja`

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -51,6 +51,18 @@ spec:
                 printf '%s' "$1" | sed -e 's/[\\/&|]/\\&/g'
               }
 
+              escape_xml() {
+                local str="$1"
+
+                str="${str//&/&amp;}"
+                str="${str//</&lt;}"
+                str="${str//>/&gt;}"
+                str="${str//\'/&apos;}"
+                str="${str//\"/&quot;}"
+
+                printf '%s' "${str}"
+              }
+
               mask_file_output() {
                 local file_path="$1"
 
@@ -209,10 +221,14 @@ spec:
               tmp_config="$(mktemp)"
               cp "${config_template}" "${tmp_config}"
 
+              jdbc_url_xml="$(escape_xml "${jdbc_url}")"
+              db_username_xml="$(escape_xml "${db_username}")"
+              db_password_xml="$(escape_xml "${db_password}")"
+
               sed -i \
-                -e "s|__JDBC_URL__|$(escape_sed "${jdbc_url}")|g" \
-                -e "s|__JDBC_USERNAME__|$(escape_sed "${db_username}")|g" \
-                -e "s|__JDBC_PASSWORD__|$(escape_sed "${db_password}")|g" \
+                -e "s|__JDBC_URL__|$(escape_sed "${jdbc_url_xml}")|g" \
+                -e "s|__JDBC_USERNAME__|$(escape_sed "${db_username_xml}")|g" \
+                -e "s|__JDBC_PASSWORD__|$(escape_sed "${db_password_xml}")|g" \
                 "${tmp_config}"
 
               if grep -q '__JDBC_' "${tmp_config}"; then


### PR DESCRIPTION
## Summary
- XML-escape JDBC URL, username and password before inserting them into config.xml so credentials with characters like & or < no longer break midPoint startup
- document the change in README for operators relying on special characters in the database secrets

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd9c5bff0c832ba8e6f34220dc0332