### PR TITLE
Fix jq expression in Argo CD apps wait step

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1633,7 +1633,7 @@ jobs:
                   | [
                       (if .health == "" then "Unknown" else .health end),
                       .kind,
-                      (if .namespace != "" then (.namespace + "/" + .name) else .name),
+                      (if .namespace != "" then (.namespace + "/" + .name) else .name end),
                       .message
                     ]
                   | @tsv


### PR DESCRIPTION
## Summary
- add the missing `end` in the jq filter used while monitoring the Argo CD `apps` application
- ensure the workflow can render the tracked resource summary without jq syntax errors

## Testing
- not run (GitHub Actions workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cda60e39c4832ba0a4e5c579ffc384