### PR TITLE
Document Keycloak service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 ## 4) Demo – what to click
 
 - Get the external IP of **ingress-nginx** (the workflow prints it; or: `kubectl -n ingress-nginx get svc ingress-nginx-controller`).
+- Keycloak is exposed through the operator-managed service `rws-keycloak-service`; check it with `kubectl -n iam get svc rws-keycloak-service` if you need the cluster IP before Ingress is ready.
 - Open Keycloak: `http://kc.<EXTERNAL-IP>.nip.io` (admin user and password are in secret `rws-keycloak-initial-admin` created by operator)
 - Open midPoint: `http://mp.<EXTERNAL-IP>.nip.io/midpoint`
   - Login: `administrator` / the `MIDPOINT_ADMIN_PASSWORD` you set


### PR DESCRIPTION
## Summary
- note that the Keycloak operator creates the rws-keycloak-service Service so operators can discover it via kubectl

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cda923b5dc832b96ec8ffd22bee73e