### PR TITLE
Ensure Keycloak operator watches iam namespace

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1571,6 +1571,41 @@ jobs:
             fi
           done
 
+      - name: Configure Keycloak operator watch namespaces
+        shell: bash
+        env:
+          IAM_NAMESPACE: ${{ inputs.NAMESPACE_IAM }}
+        run: |
+          set -euo pipefail
+
+          operator_namespace=""
+          for ns in keycloak keycloak-system default; do
+            if kubectl -n "${ns}" get deployment keycloak-operator >/dev/null 2>&1; then
+              operator_namespace="${ns}"
+              break
+            fi
+          done
+
+          if [ -z "${operator_namespace}" ]; then
+            echo "Unable to locate keycloak-operator deployment in expected namespaces (keycloak, keycloak-system, default)."
+            echo "Available deployments:" || true
+            kubectl get deployments -A || true
+            exit 1
+          fi
+
+          watch_namespaces="${IAM_NAMESPACE}"
+          if [ "${IAM_NAMESPACE}" != "${operator_namespace}" ]; then
+            watch_namespaces="${watch_namespaces},${operator_namespace}"
+          fi
+
+          echo "Configuring keycloak-operator in namespace ${operator_namespace} to watch: ${watch_namespaces}"
+          kubectl -n "${operator_namespace}" set env deployment/keycloak-operator \
+            QUARKUS_OPERATOR_SDK_NAMESPACES="${watch_namespaces}" \
+            QUARKUS_OPERATOR_SDK_GENERATE_WITH_WATCHED_NAMESPACES="${watch_namespaces}" \
+            --overwrite
+
+          kubectl -n "${operator_namespace}" rollout status deployment/keycloak-operator --timeout=300s
+
       - name: Create Argo CD application for iam apps (Keycloak + midPoint)
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Run a one-off PostgreSQL job that ensures the `midpoint` database and role exist before midPoint starts
    - Enable the required PostgreSQL extensions (`pgcrypto`, `pg_trgm`) for midPoint
    - Install **Keycloak Operator** then create a **Keycloak** CR bound to CNPG
+     - The workflow now reconfigures the operator deployment to watch the `iam` application namespace (in addition to its home namespace) so it publishes the generated services, such as `rws-keycloak-service`, where Argo CD manages the workloads.
    - Deploy **midPoint** bound to CNPG
    - Create a Kubernetes **Secret** with Azure Blob credentials (from repo secrets) for CNPG backups
    - Purge any existing WAL/archive blobs in the Azure `cnpg-backups/iam-db` prefix so CloudNativePG can bootstrap cleanly on reruns


### PR DESCRIPTION
## Summary
- patch the bootstrap workflow to configure the Keycloak operator deployment so it watches the IAM namespace and recreates its rollout with the updated environment
- document in the README that the workflow now reconfigures the operator to publish services such as `rws-keycloak-service` in the IAM namespace

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cdabc418d8832b872ab4650ea8ce1b