### PR TITLE
Improve keycloak operator namespace update reliability

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1598,13 +1598,126 @@ jobs:
             watch_namespaces="${watch_namespaces},${operator_namespace}"
           fi
 
+          watch_namespaces="$(python3 - "$watch_namespaces" <<'PY'
+import sys
+
+raw = sys.argv[1]
+parts = [part.strip() for part in raw.split(',') if part.strip()]
+seen = set()
+ordered = []
+for part in parts:
+    if part not in seen:
+        seen.add(part)
+        ordered.append(part)
+print(','.join(ordered))
+PY
+)"
+
+          if [ -z "${watch_namespaces}" ]; then
+            echo "Computed watch namespace list is empty; refusing to update keycloak-operator configuration."
+            exit 1
+          fi
+
+          canonicalize_csv() {
+            local raw="$1"
+            python3 - "$raw" <<'PY'
+import sys
+
+raw = sys.argv[1]
+parts = sorted({part.strip() for part in raw.split(',') if part.strip()})
+print(','.join(parts))
+PY
+          }
+
+          get_env_value() {
+            local env_name="$1"
+            kubectl -n "${operator_namespace}" get deployment keycloak-operator -o json \
+              | jq -r --arg name "${env_name}" '
+                (
+                  [
+                    .spec.template.spec.containers[]
+                    | select(.name == "keycloak-operator")
+                    | (.env // [])
+                    | .[]
+                    | select(.name == $name)
+                    | .value
+                  ][0]
+                ) // ""
+              '
+          }
+
+          desired_canonical="$(canonicalize_csv "${watch_namespaces}")"
+          current_namespaces_raw="$(get_env_value "QUARKUS_OPERATOR_SDK_NAMESPACES")"
+          current_generate_raw="$(get_env_value "QUARKUS_OPERATOR_SDK_GENERATE_WITH_WATCHED_NAMESPACES")"
+          current_namespaces_canonical="$(canonicalize_csv "${current_namespaces_raw}")"
+          current_generate_canonical="$(canonicalize_csv "${current_generate_raw}")"
+
+          if [ "${current_namespaces_canonical}" = "${desired_canonical}" ] && \
+             [ "${current_generate_canonical}" = "${desired_canonical}" ]; then
+            echo "Keycloak operator already configured to watch namespaces: ${current_namespaces_raw:-<unset>}"
+            exit 0
+          fi
+
           echo "Configuring keycloak-operator in namespace ${operator_namespace} to watch: ${watch_namespaces}"
           kubectl -n "${operator_namespace}" set env deployment/keycloak-operator \
             QUARKUS_OPERATOR_SDK_NAMESPACES="${watch_namespaces}" \
             QUARKUS_OPERATOR_SDK_GENERATE_WITH_WATCHED_NAMESPACES="${watch_namespaces}" \
             --overwrite
 
-          kubectl -n "${operator_namespace}" rollout status deployment/keycloak-operator --timeout=300s
+          wait_for_rollout() {
+            local timeout_value="$1"
+            set +e
+            kubectl -n "${operator_namespace}" rollout status deployment/keycloak-operator --timeout="${timeout_value}"
+            local status=$?
+            set -e
+            return "${status}"
+          }
+
+          if wait_for_rollout 300s; then
+            echo "keycloak-operator deployment rollout completed successfully."
+            exit 0
+          fi
+
+          echo "Initial rollout did not complete within the expected time; gathering diagnostics."
+          kubectl -n "${operator_namespace}" get pods -l app.kubernetes.io/name=keycloak-operator -o wide || true
+
+          mapfile -t terminating_pods < <(
+            kubectl -n "${operator_namespace}" get pods -l app.kubernetes.io/name=keycloak-operator -o json \
+              | jq -r '.items[] | select(.metadata.deletionTimestamp != null) | .metadata.name'
+          )
+
+          if [ "${#terminating_pods[@]}" -gt 0 ]; then
+            echo "Force-deleting stuck terminating keycloak-operator pods: ${terminating_pods[*]}"
+            for pod in "${terminating_pods[@]}"; do
+              kubectl -n "${operator_namespace}" delete pod "${pod}" --force --grace-period=0 || true
+            done
+
+            if wait_for_rollout 240s; then
+              echo "keycloak-operator deployment rollout completed after removing terminating pods."
+              exit 0
+            fi
+
+            echo "Rollout still failing after retry; collecting detailed diagnostics."
+          else
+            echo "No terminating pods detected; collecting detailed diagnostics for failed rollout."
+          fi
+
+          kubectl -n "${operator_namespace}" describe deployment keycloak-operator || true
+          kubectl -n "${operator_namespace}" get pods -l app.kubernetes.io/name=keycloak-operator -o yaml || true
+
+          mapfile -t operator_pods < <(
+            kubectl -n "${operator_namespace}" get pods -l app.kubernetes.io/name=keycloak-operator -o json \
+              | jq -r '.items[] | .metadata.name'
+          )
+
+          if [ "${#operator_pods[@]}" -gt 0 ]; then
+            for pod in "${operator_pods[@]}"; do
+              echo "Logs for pod ${pod}:"
+              kubectl -n "${operator_namespace}" logs "${pod}" || true
+            done
+          fi
+
+          exit 1
 
       - name: Create Argo CD application for iam apps (Keycloak + midPoint)
         shell: bash


### PR DESCRIPTION
## Summary
- avoid unnecessary restarts by canonicalizing the desired Keycloak operator watch namespace list and skipping updates when the current configuration already matches
- add rollout retry logic that force-deletes stuck terminating Keycloak operator pods and emits detailed diagnostics when the deployment does not settle

## Testing
- not run (workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68ce487cebb0832bb6f485c587a6914f