### PR TITLE
Fix YAML indentation issues in Argo CD bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1654,20 +1654,7 @@ jobs:
             watch_namespaces="${watch_namespaces},${operator_namespace}"
           fi
 
-          watch_namespaces="$(python3 - "$watch_namespaces" <<'PY'
-import sys
-
-raw = sys.argv[1]
-parts = [part.strip() for part in raw.split(',') if part.strip()]
-seen = set()
-ordered = []
-for part in parts:
-    if part not in seen:
-        seen.add(part)
-        ordered.append(part)
-print(','.join(ordered))
-PY
-)"
+          watch_namespaces="$(python3 -c 'import sys; raw = sys.argv[1]; parts = [part.strip() for part in raw.split(",") if part.strip()]; print(",".join(dict.fromkeys(parts)))' "$watch_namespaces")"
 
           if [ -z "${watch_namespaces}" ]; then
             echo "Computed watch namespace list is empty; refusing to update keycloak-operator configuration."
@@ -1676,13 +1663,7 @@ PY
 
           canonicalize_csv() {
             local raw="$1"
-            python3 - "$raw" <<'PY'
-import sys
-
-raw = sys.argv[1]
-parts = sorted({part.strip() for part in raw.split(',') if part.strip()})
-print(','.join(parts))
-PY
+            python3 -c 'import sys; raw = sys.argv[1]; parts = sorted({part.strip() for part in raw.split(",") if part.strip()}); print(",".join(parts))' "$raw"
           }
 
           get_env_value() {


### PR DESCRIPTION
## Summary
- replace here-doc Python snippets with `python3 -c` one-liners so the workflow script stays valid YAML
- keep namespace canonicalization logic while ensuring the workflow parses correctly

## Testing
- `yamllint .github/workflows/02_bootstrap_argocd.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4adc6ab8832b86b8c4a54af6f47e