### PR TITLE
Enable Keycloak auto-build to keep DB config in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     clears `spec.realm`, so Argo CD ignores differences on that path to avoid endless resyncs. When you change the realm
     payload, bump `metadata.annotations.iam.demo/realm-config-version` so Argo CD reapplies the manifest and Keycloak
     performs a fresh import.
+  - Keycloak now sets `kc.auto-build=true` so the server automatically rebuilds its optimized configuration whenever database
+    or health-check options change. Without this flag the pod can crash-loop after password rotations or image upgrades because
+    the runtime options would not match the persisted build-time configuration.
 
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
   - The deployment constrains the JVM heap (`MP_MEM_INIT=768M`, `MP_MEM_MAX=1536M`) to keep resource usage predictable.

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   image: quay.io/keycloak/keycloak:26.0
   instances: 1
+  additionalOptions:
+    - name: kc.auto-build
+      value: "true"
   db:
     vendor: postgres
     host: iam-db-rw.iam.svc.cluster.local


### PR DESCRIPTION
## Summary
- allow the Keycloak CR to turn on `kc.auto-build` so the pod rebuilds its optimized configuration instead of crashing when database or health settings change
- document the new auto-build behavior for operators in the Keycloak section of the README

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce5a36dca4832bb2c7b552a462b5d9