### PR TITLE
Enable Keycloak auto-build to recover from build option changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     clears `spec.realm`, so Argo CD ignores differences on that path to avoid endless resyncs. When you change the realm
     payload, bump `metadata.annotations.iam.demo/realm-config-version` so Argo CD reapplies the manifest and Keycloak
     performs a fresh import.
+  - Keycloak now sets `kc.auto-build=true` and explicitly enables the `health` feature so the container rebuilds itself when
+    build-time options such as the database vendor or health endpoints change. This keeps the operator-driven liveness and
+    readiness probes working even after upgrades or secret rotations because the server automatically refreshes the optimized
+    build instead of exiting with "build time options" errors.
 
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
   - The deployment constrains the JVM heap (`MP_MEM_INIT=768M`, `MP_MEM_MAX=1536M`) to keep resource usage predictable.

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -4,6 +4,11 @@ metadata:
   name: rws-keycloak
   namespace: iam
 spec:
+  additionalOptions:
+    - name: kc.auto-build
+      value: "true"
+    - name: kc.health-enabled
+      value: "true"
   image: quay.io/keycloak/keycloak:26.0
   instances: 1
   db:
@@ -19,6 +24,9 @@ spec:
       key: password
   http:
     httpEnabled: true
+  features:
+    enabled:
+      - health
   hostname:
     strict: false
   ingress:


### PR DESCRIPTION
## Summary
- enable Keycloak auto-build and health features in the Keycloak CR so the pod rebuilds itself when build-time settings change
- document the auto-build behaviour in the Keycloak section of the README for operators

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce5a36dca4832bb2c7b552a462b5d9