### PR TITLE
Fix Keycloak crash caused by invalid auto-build flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     clears `spec.realm`, so Argo CD ignores differences on that path to avoid endless resyncs. When you change the realm
     payload, bump `metadata.annotations.iam.demo/realm-config-version` so Argo CD reapplies the manifest and Keycloak
     performs a fresh import.
-  - Keycloak now sets the CLI options `auto-build=true` and `health-enabled=true` so the server automatically rebuilds its
-    optimized configuration and exposes the readiness endpoints every time the database or health-check settings change.
-    Without the auto-build flag the pod can crash-loop after password rotations or image upgrades because the runtime
-    options would not match the persisted build-time configuration, and without the health flag the operator's probes would
-    never succeed.
+  - Keycloak now sets the configuration property `kc.auto-build=true` (so the operator keeps the persisted build-time
+    configuration in sync with the runtime options) and the CLI flag `health-enabled=true` (so the readiness endpoints are
+    exposed for the operator's probes). Without the auto-build property the pod can crash-loop after password rotations or
+    image upgrades because the runtime options would not match the persisted build-time configuration, and without the
+    health flag the operator's probes would never succeed.
 
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
   - The deployment constrains the JVM heap (`MP_MEM_INIT=768M`, `MP_MEM_MAX=1536M`) to keep resource usage predictable.

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -7,7 +7,7 @@ spec:
   image: quay.io/keycloak/keycloak:26.0
   instances: 1
   additionalOptions:
-    - name: auto-build
+    - name: kc.auto-build
       value: "true"
     - name: health-enabled
       value: "true"


### PR DESCRIPTION
## Summary
- restore the Keycloak CR to use `kc.auto-build=true` so the operator writes the option into the config file instead of passing the removed `--auto-build` CLI flag that crashes Keycloak 26
- keep `health-enabled=true` for readiness checks and clarify the README about the correct option names

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce686b4ef4832b98df95990065ba7e