### PR TITLE
Ensure Keycloak env keeps JDBC URL query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     image upgrades because the runtime options would not match the persisted build-time configuration, and without the
     health flag the operator's probes would never succeed.
   - The PostgreSQL connection now uses an explicit JDBC URL with `sslmode=disable` so Keycloak skips TLS validation against
-    CloudNativePG's self-signed server certificate. Without this override the startup probe repeatedly fails with
-    `connection refused`, the pod restarts, and the application never reaches Healthy.
+    CloudNativePG's self-signed server certificate. The value is injected via `KC_DB_URL` in addition to the CRD field so the
+    exact JDBC string (including the query parameters) always reaches the container even if the operator rewrites the
+    database options. Without this override the startup probe repeatedly fails with `connection refused`, the pod restarts,
+    and the application never reaches Healthy.
 
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
   - The deployment constrains the JVM heap (`MP_MEM_INIT=768M`, `MP_MEM_MAX=1536M`) to keep resource usage predictable.

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   image: quay.io/keycloak/keycloak:26.0
   instances: 1
+  env:
+    - name: KC_DB_URL
+      value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable
   additionalOptions:
     - name: kc.auto-build
       value: "true"


### PR DESCRIPTION
## Summary
- explicitly set `KC_DB_URL` so Keycloak always receives the JDBC URL with `sslmode=disable`
- document the additional environment override in the Keycloak configuration section of the README

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ce8f1df3ac832b852605f1ab672bf8