### PR TITLE
Fix Keycloak health configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     clears `spec.realm`, so Argo CD ignores differences on that path to avoid endless resyncs. When you change the realm
     payload, bump `metadata.annotations.iam.demo/realm-config-version` so Argo CD reapplies the manifest and Keycloak
     performs a fresh import.
-  - Keycloak enables the CLI flag `health-enabled=true` so the readiness endpoints are exposed for the operator's probes.
-    Keycloak 26 automatically rebuilds the optimized image when runtime options change, and the legacy `auto-build`
-    configuration knob was removed upstream. Leaving the old `kc.auto-build=true` entry forces the operator to render the
-    invalid `--kc.auto-build` flag which causes the pod to exit immediately, so the manifest purposely omits that option.
+  - Keycloak enables the `health` feature through `.spec.features.enabled` so the operator's readiness probes expose the
+    management endpoints without relying on legacy CLI flags. Using the older `health-enabled` CLI option left the
+    optimized build in an inconsistent state, so Keycloak 26 exited with code 2 and the pod crash-looped even though the
+    probes kept retrying. Keycloak 26 automatically rebuilds the optimized image when feature toggles change, and the
+    legacy `kc.auto-build` flag was removed upstream. Leaving the old option in place forces the operator to render an
+    invalid `--kc.auto-build` argument that makes the pod exit immediately, so the manifest purposely omits it.
   - The PostgreSQL connection now uses an explicit JDBC URL with `sslmode=disable` so Keycloak skips TLS validation against
     CloudNativePG's self-signed server certificate. The value is injected via `KC_DB_URL` in addition to the CRD field so the
     exact JDBC string (including the query parameters) always reaches the container even if the operator rewrites the

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -9,9 +9,9 @@ spec:
   env:
     - name: KC_DB_URL
       value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable
-  additionalOptions:
-    - name: health-enabled
-      value: "true"
+  features:
+    enabled:
+      - health
   db:
     vendor: postgres
     url: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable


### PR DESCRIPTION
## Summary
- enable Keycloak health endpoints via the new `.spec.features.enabled` block instead of the legacy CLI flag
- document the change in the Keycloak operator notes so future updates keep using the supported mechanism

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cea7d9d83c832ba0a2ed6458c12ed5