### PR TITLE
Disable optimized Keycloak start to avoid crash loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     clears `spec.realm`, so Argo CD ignores differences on that path to avoid endless resyncs. When you change the realm
     payload, bump `metadata.annotations.iam.demo/realm-config-version` so Argo CD reapplies the manifest and Keycloak
     performs a fresh import.
+  - `startOptimized` is explicitly disabled so the container re-runs `kc.sh build` with the database and health check
+    settings every time the pod starts. Keycloak 26 exits early with `The following build time options have values that
+    differ...` when the optimized image still carries the default `kc.db=dev-file`/`kc.health-enabled=false` values from
+    the upstream image, so letting the runtime build step execute avoids the crash loop without having to maintain a
+    pre-built custom image.
   - Keycloak enables the CLI flag `health-enabled=true` so the readiness endpoints are exposed for the operator's probes.
     Keycloak 26 automatically rebuilds the optimized image when runtime options change, and the legacy `auto-build`
     configuration knob was removed upstream. Leaving the old `kc.auto-build=true` entry forces the operator to render the

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   image: quay.io/keycloak/keycloak:26.0
   instances: 1
+  startOptimized: false
   env:
     - name: KC_DB_URL
       value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable


### PR DESCRIPTION
## Summary
- set `startOptimized` to `false` on the Keycloak CR so the container reruns `kc.sh build` with the live database settings
- document in the README why optimized mode causes the Keycloak pod to exit when build-time options change

## Testing
- not run (configuration-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cea7d9d83c832ba0a2ed6458c12ed5