### PR TITLE
fix: upgrade keycloak image to resolve build option crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     payload, bump `metadata.annotations.iam.demo/realm-config-version` so Argo CD reapplies the manifest and Keycloak
     performs a fresh import.
   - Keycloak enables the CLI flag `health-enabled=true` so the readiness endpoints are exposed for the operator's probes.
+    The manifest pins Keycloak to **26.0.8** because 26.0.0 fails to start once build-time options such as `kc.db`
+    or `kc.health-enabled` diverge from what was baked into the optimized image, which is exactly the case for this
+    deployment. The regression was fixed upstream (Keycloak issue #33902) and shipping the patched image ensures the
+    StatefulSet does not get stuck in a CrashLoopBackOff when we reconcile the database and health settings.
     Keycloak 26 automatically rebuilds the optimized image when runtime options change, and the legacy `auto-build`
     configuration knob was removed upstream. Leaving the old `kc.auto-build=true` entry forces the operator to render the
     invalid `--kc.auto-build` flag which causes the pod to exit immediately, so the manifest purposely omits that option.

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rws-keycloak
   namespace: iam
 spec:
-  image: quay.io/keycloak/keycloak:26.0
+  image: quay.io/keycloak/keycloak:26.0.8
   instances: 1
   env:
     - name: KC_DB_URL


### PR DESCRIPTION
## Summary
- upgrade the Keycloak workload to the patched 26.0.8 image so build-time database and health flags no longer crash the pod
- document in the README why the deployment is pinned to the fixed image and reference the upstream regression

## Testing
- not run (Kubernetes manifest and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cea7d9d83c832ba0a2ed6458c12ed5