### PR TITLE
Fix Keycloak crash caused by removed health feature toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     the upstream image, so letting the runtime build step execute avoids the crash loop without having to maintain a
     pre-built custom image.
   - Keycloak enables the CLI flag `health-enabled=true` so the readiness endpoints are exposed for the operator's probes.
+    Keycloak 26.0.8 removed the legacy `health` feature toggle, so the manifest now sets `KC_HEALTH_ENABLED=true`
+    directly instead of relying on `spec.features.enabled`. Leaving the old flag in place makes the container exit with
+    `health is an unrecognized feature`, which surfaces as a CrashLoopBackOff in Argo CD. If you upgrade the image again
+    and the health endpoints disappear, review the upstream release notes for the replacement environment variable or
+    CLI flag before reintroducing a features list.
     The manifest pins Keycloak to **26.0.8** because 26.0.0 fails to start once build-time options such as `kc.db`
     or `kc.health-enabled` diverge from what was baked into the optimized image, which is exactly the case for this
     deployment. The regression was fixed upstream (Keycloak issue #33902) and shipping the patched image ensures the

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -10,9 +10,8 @@ spec:
   env:
     - name: KC_DB_URL
       value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable
-  features:
-    enabled:
-      - health
+    - name: KC_HEALTH_ENABLED
+      value: "true"
   db:
     vendor: postgres
     url: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable


### PR DESCRIPTION
## Summary
- stop requesting the removed `health` feature flag in the Keycloak CR and keep health endpoints on via `KC_HEALTH_ENABLED`
- document the change so future upgrades know to use the environment variable instead of the legacy feature toggle

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68ceb37e2a08832bac466b964731ab14