### PR TITLE
Fix Keycloak health feature crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - Keycloak enables the CLI flag `health-enabled=true` so the readiness endpoints are exposed for the operator's probes.
     Keycloak 26.0.8 removed the legacy `health` feature toggle, so the manifest now sets `KC_HEALTH_ENABLED=true`
     directly instead of relying on `spec.features.enabled`. Leaving the old flag in place makes the container exit with
-    `health is an unrecognized feature`, which surfaces as a CrashLoopBackOff in Argo CD. If you upgrade the image again
-    and the health endpoints disappear, review the upstream release notes for the replacement environment variable or
-    CLI flag before reintroducing a features list.
+    `health is an unrecognized feature`, which surfaces as a CrashLoopBackOff in Argo CD. The Keycloak Operator still
+    defaults to enabling the obsolete `health` feature, so the manifest explicitly sets `spec.features.enabled: []` to
+    override that default and keep `KC_FEATURES` empty. If you upgrade the image again and the health endpoints disappear,
+    review the upstream release notes for the replacement environment variable or CLI flag before reintroducing a features
+    list.
     The manifest pins Keycloak to **26.0.8** because 26.0.0 fails to start once build-time options such as `kc.db`
     or `kc.health-enabled` diverge from what was baked into the optimized image, which is exactly the case for this
     deployment. The regression was fixed upstream (Keycloak issue #33902) and shipping the patched image ensures the

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -12,6 +12,12 @@ spec:
       value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable
     - name: KC_HEALTH_ENABLED
       value: "true"
+  # Disable the operator's default feature toggles so it does not inject the
+  # legacy "health" feature into KC_FEATURES. Keycloak 26 removed that flag
+  # and will crash if we request it, so we enable the health endpoints via
+  # KC_HEALTH_ENABLED instead.
+  features:
+    enabled: []
   db:
     vendor: postgres
     url: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable


### PR DESCRIPTION
## Summary
- explicitly disable Keycloak feature toggles in the CR to prevent the operator from injecting the removed `health` feature
- document in the README why `spec.features.enabled: []` is now required alongside `KC_HEALTH_ENABLED`

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cec58f0420832b815003c674ad141b