### PR TITLE
Disable Keycloak health feature to stop crash loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     Keycloak 26.0.8 removed the legacy `health` feature toggle, so the manifest now sets `KC_HEALTH_ENABLED=true`
     directly instead of relying on `spec.features.enabled`. Leaving the old flag in place makes the container exit with
     `health is an unrecognized feature`, which surfaces as a CrashLoopBackOff in Argo CD. The Keycloak Operator still
-    defaults to enabling the obsolete `health` feature, so the manifest explicitly sets `spec.features.enabled: []` to
-    override that default and keep `KC_FEATURES` empty. If you upgrade the image again and the health endpoints disappear,
-    review the upstream release notes for the replacement environment variable or CLI flag before reintroducing a features
-    list.
+    defaults to enabling the obsolete `health` feature even when the enabled list is empty, so the manifest explicitly
+    sets `spec.features.enabled: []` **and** `spec.features.disabled: ["health"]` to override that default and keep
+    `KC_FEATURES` empty. If you upgrade the image again and the health endpoints disappear, review the upstream release
+    notes for the replacement environment variable or CLI flag before reintroducing a features list.
     The manifest pins Keycloak to **26.0.8** because 26.0.0 fails to start once build-time options such as `kc.db`
     or `kc.health-enabled` diverge from what was baked into the optimized image, which is exactly the case for this
     deployment. The regression was fixed upstream (Keycloak issue #33902) and shipping the patched image ensures the

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -15,9 +15,12 @@ spec:
   # Disable the operator's default feature toggles so it does not inject the
   # legacy "health" feature into KC_FEATURES. Keycloak 26 removed that flag
   # and will crash if we request it, so we enable the health endpoints via
-  # KC_HEALTH_ENABLED instead.
+  # KC_HEALTH_ENABLED instead. The operator still adds "health" when the
+  # enabled list is empty, so explicitly disable it to keep KC_FEATURES blank.
   features:
     enabled: []
+    disabled:
+      - health
   db:
     vendor: postgres
     url: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable


### PR DESCRIPTION
## Summary
- explicitly disable the legacy Keycloak `health` feature so the operator no longer injects an invalid KC_FEATURES flag
- document the change in the README so operators know why both the enabled and disabled lists are configured

## Testing
- not run (GitOps manifest change)


------
https://chatgpt.com/codex/tasks/task_e_68cecd630b78832bbcfb17cb7854ddfe