### PR TITLE
Fix Keycloak feature flag crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - Keycloak enables the CLI flag `health-enabled=true` so the readiness endpoints are exposed for the operator's probes.
     Keycloak 26.0.8 removed the legacy `health` feature toggle, so the manifest now sets `KC_HEALTH_ENABLED=true`
     directly instead of relying on `spec.features.enabled`. Leaving the old flag in place makes the container exit with
-    `health is an unrecognized feature`, which surfaces as a CrashLoopBackOff in Argo CD. The Keycloak Operator still
-    defaults to enabling the obsolete `health` feature, so the manifest explicitly sets `spec.features.enabled: []` to
-    override that default and keep `KC_FEATURES` empty. If you upgrade the image again and the health endpoints disappear,
-    review the upstream release notes for the replacement environment variable or CLI flag before reintroducing a features
-    list.
+    `health is an unrecognized feature`, which surfaces as a CrashLoopBackOff in Argo CD. The current Keycloak Operator
+    release still injects `health` into `KC_FEATURES` whenever the list is empty, so the manifest pins
+    `spec.features.enabled` to a harmless feature (`token-exchange`) to force the operator to stop requesting the
+    removed flag. If you upgrade the image again and the health endpoints disappear, review the upstream release notes
+    for the replacement environment variable or CLI flag before adjusting the feature list.
     The manifest pins Keycloak to **26.0.8** because 26.0.0 fails to start once build-time options such as `kc.db`
     or `kc.health-enabled` diverge from what was baked into the optimized image, which is exactly the case for this
     deployment. The regression was fixed upstream (Keycloak issue #33902) and shipping the patched image ensures the

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -17,7 +17,11 @@ spec:
   # and will crash if we request it, so we enable the health endpoints via
   # KC_HEALTH_ENABLED instead.
   features:
-    enabled: []
+    # The operator still injects the deprecated "health" feature when no explicit
+    # list is provided. Keycloak 26 removed that toggle, so selecting any valid
+    # feature forces the operator to stop requesting "health".
+    enabled:
+      - token-exchange
   db:
     vendor: postgres
     url: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable


### PR DESCRIPTION
## Summary
- stop the Keycloak operator from injecting the removed `health` feature by explicitly requesting a supported feature
- document the new workaround in the deployment notes so future upgrades know why `token-exchange` stays enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cecd630b78832bbcfb17cb7854ddfe