### PR TITLE
Fix Keycloak crash by overriding operator health feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     directly instead of relying on `spec.features.enabled`. Leaving the old flag in place makes the container exit with
     `health is an unrecognized feature`, which surfaces as a CrashLoopBackOff in Argo CD. The current Keycloak Operator
     release still injects `health` into `KC_FEATURES` whenever the list is empty, so the manifest pins
-    `spec.features.enabled` to a harmless feature (`token-exchange`) to force the operator to stop requesting the
-    removed flag. If you upgrade the image again and the health endpoints disappear, review the upstream release notes
-    for the replacement environment variable or CLI flag before adjusting the feature list.
+    `spec.features.enabled` (and the raw `KC_FEATURES` environment variable) to a harmless feature (`token-exchange`)
+    to force the operator to stop requesting the removed flag. If you upgrade the image again and the health endpoints
+    disappear, review the upstream release notes for the replacement environment variable or CLI flag before adjusting
+    the feature list.
 
   - The manifest pins Keycloak to **26.0.8** because 26.0.0 fails to start once build-time options such as `kc.db`
     or `kc.health-enabled` diverge from what was baked into the optimized image, which is exactly the case for this

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -12,13 +12,20 @@ spec:
       value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable
     - name: KC_HEALTH_ENABLED
       value: "true"
+    # Pin a safe default features list so the operator stops appending the
+    # removed "health" toggle. The 26.0.8 operator still injects its defaults
+    # whenever the enabled list is empty, which makes the pod exit with
+    # "health is an unrecognized feature".
+    - name: KC_FEATURES
+      value: token-exchange
   # Disable the operator's default feature toggles so it does not inject the
   # legacy "health" feature into KC_FEATURES. Keycloak 26 removed that flag
   # and will crash if we request it, so we enable the health endpoints via
   # KC_HEALTH_ENABLED instead. The operator still adds "health" when the
   # enabled list is empty, so explicitly disable it to keep KC_FEATURES blank.
   features:
-    enabled: []
+    enabled:
+      - token-exchange
     disabled:
       - health
   db:


### PR DESCRIPTION
## Summary
- keep the Keycloak operator from reintroducing the removed `health` feature by pinning `KC_FEATURES` and the CR's enabled list to `token-exchange`
- document the operator quirk and the explicit feature overrides in the Keycloak configuration guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cef16e5b8c832bbf4520918b617f3a