### PR TITLE
Stop requesting removed Keycloak health feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     `health is an unrecognized feature`, which surfaces as a CrashLoopBackOff in Argo CD. The current Keycloak Operator
     release still injects `health` into `KC_FEATURES` whenever the list is empty, so the manifest pins
     `spec.features.enabled` (and the raw `KC_FEATURES` environment variable) to a harmless feature (`token-exchange`)
-    to force the operator to stop requesting the removed flag. If you upgrade the image again and the health endpoints
-    disappear, review the upstream release notes for the replacement environment variable or CLI flag before adjusting
-    the feature list.
+    to force the operator to stop requesting the removed flag. Setting `spec.features.disabled` to `health` still makes
+    the operator render the removed flag, so the disabled list stays empty and the manifest relies solely on the explicit
+    enabled entry. If you upgrade the image again and the health endpoints disappear, review the upstream release notes
+    for the replacement environment variable or CLI flag before adjusting the feature list.
 
   - The manifest pins Keycloak to **26.0.8** because 26.0.0 fails to start once build-time options such as `kc.db`
     or `kc.health-enabled` diverge from what was baked into the optimized image, which is exactly the case for this

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -18,16 +18,15 @@ spec:
     # "health is an unrecognized feature".
     - name: KC_FEATURES
       value: token-exchange
-  # Disable the operator's default feature toggles so it does not inject the
-  # legacy "health" feature into KC_FEATURES. Keycloak 26 removed that flag
+  # Pin the operator's feature list to a known good entry so it does not inject
+  # the legacy "health" feature into KC_FEATURES. Keycloak 26 removed that flag
   # and will crash if we request it, so we enable the health endpoints via
   # KC_HEALTH_ENABLED instead. The operator still adds "health" when the
-  # enabled list is empty, so explicitly disable it to keep KC_FEATURES blank.
+  # enabled list is empty, so explicitly enable a harmless feature to keep
+  # KC_FEATURES stable.
   features:
     enabled:
       - token-exchange
-    disabled:
-      - health
   db:
     vendor: postgres
     url: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable


### PR DESCRIPTION
## Summary
- keep the Keycloak Operator from rendering the removed `--features=health` flag by only enabling a harmless feature
- document in the README why the disabled list must stay empty when Keycloak 26 exposes health checks through `KC_HEALTH_ENABLED`

## Testing
- not run (manifest/readme only)


------
https://chatgpt.com/codex/tasks/task_e_68cf04944a00832b81c6864e4950a657