### PR TITLE
Fix YAML syntax in demo host workflow

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -90,30 +90,30 @@ jobs:
           set -euo pipefail
           if kubectl -n "$NAMESPACE" get ingress midpoint >/dev/null 2>&1; then
             echo "Patching existing midPoint Ingress host -> ${MP_HOST}"
-            kubectl -n "$NAMESPACE" patch ingress midpoint --type=json               -p="[{'op':'replace','path':'/spec/rules/0/host','value':'${MP_HOST}'}]"
+            kubectl -n "$NAMESPACE" patch ingress midpoint --type=json -p="[{'op':'replace','path':'/spec/rules/0/host','value':'${MP_HOST}'}]"
           else
             echo "Creating midPoint Ingress with host ${MP_HOST}"
-            cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: midpoint
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: ${MP_HOST}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: midpoint
-            port:
-              number: 8080
-EOF
+            printf '%s\n' \
+              'apiVersion: networking.k8s.io/v1' \
+              'kind: Ingress' \
+              'metadata:' \
+              '  name: midpoint' \
+              '  annotations:' \
+              '    nginx.ingress.kubernetes.io/proxy-body-size: "16m"' \
+              'spec:' \
+              '  ingressClassName: nginx' \
+              '  rules:' \
+              "  - host: ${MP_HOST}" \
+              '    http:' \
+              '      paths:' \
+              '      - path: /' \
+              '        pathType: Prefix' \
+              '        backend:' \
+              '          service:' \
+              '            name: midpoint' \
+              '            port:' \
+              '              number: 8080' \
+            | kubectl -n "$NAMESPACE" apply -f -
           fi
           kubectl -n "$NAMESPACE" get ingress midpoint -o wide
 
@@ -126,27 +126,27 @@ EOF
         run: |
           set -euo pipefail
           echo "Applying Keycloak public Ingress for host ${KC_HOST} -> ${SVC}:${PORT}"
-          cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: rws-keycloak-public
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: ${KC_HOST}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: ${SVC}
-            port:
-              number: ${PORT}
-EOF
+          printf '%s\n' \
+            'apiVersion: networking.k8s.io/v1' \
+            'kind: Ingress' \
+            'metadata:' \
+            '  name: rws-keycloak-public' \
+            '  annotations:' \
+            '    nginx.ingress.kubernetes.io/proxy-body-size: "16m"' \
+            'spec:' \
+            '  ingressClassName: nginx' \
+            '  rules:' \
+            "  - host: ${KC_HOST}" \
+            '    http:' \
+            '      paths:' \
+            '      - path: /' \
+            '        pathType: Prefix' \
+            '        backend:' \
+            '          service:' \
+            "            name: ${SVC}" \
+            '            port:' \
+            "              number: ${PORT}" \
+          | kubectl -n "$NAMESPACE" apply -f -
           kubectl -n "$NAMESPACE" get ingress rws-keycloak-public -o wide
 
       - name: Smoke-test endpoints


### PR DESCRIPTION
## Summary
- replace inline heredocs in the demo host workflow with printf pipelines so the YAML parses correctly
- keep the midPoint ingress patch/update logic intact while switching manifest rendering away from heredocs

## Testing
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/04_configure_demo_hosts.yml")'`


------
https://chatgpt.com/codex/tasks/task_e_68cf1aa69be8832b8a479164f630fdab