### PR TITLE
Fix heredoc indentation in demo hosts workflow

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -94,26 +94,26 @@ jobs:
           else
             echo "Creating midPoint Ingress with host ${MP_HOST}"
             cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: midpoint
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: ${MP_HOST}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
             name: midpoint
-            port:
-              number: 8080
-EOF
+            annotations:
+              nginx.ingress.kubernetes.io/proxy-body-size: "16m"
+          spec:
+            ingressClassName: nginx
+            rules:
+            - host: ${MP_HOST}
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: midpoint
+                      port:
+                        number: 8080
+          EOF
           fi
           kubectl -n "$NAMESPACE" get ingress midpoint -o wide
 
@@ -127,26 +127,26 @@ EOF
           set -euo pipefail
           echo "Applying Keycloak public Ingress for host ${KC_HOST} -> ${SVC}:${PORT}"
           cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: rws-keycloak-public
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: ${KC_HOST}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: ${SVC}
-            port:
-              number: ${PORT}
-EOF
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: rws-keycloak-public
+            annotations:
+              nginx.ingress.kubernetes.io/proxy-body-size: "16m"
+          spec:
+            ingressClassName: nginx
+            rules:
+            - host: ${KC_HOST}
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: ${SVC}
+                      port:
+                        number: ${PORT}
+          EOF
           kubectl -n "$NAMESPACE" get ingress rws-keycloak-public -o wide
 
       - name: Smoke-test endpoints


### PR DESCRIPTION
## Summary
- fix the heredoc indentation in the configure demo hosts workflow so the YAML parses correctly

## Testing
- python - <<'PY'
import yaml, sys
from pathlib import Path
try:
    yaml.safe_load(Path('.github/workflows/04_configure_demo_hosts.yml').read_text())
except Exception as e:
    sys.exit(f"YAML error: {e}")
print('YAML parsed successfully')
PY

------
https://chatgpt.com/codex/tasks/task_e_68cf1aa69be8832b8a479164f630fdab