### PR TITLE
Fix JSON patch quoting in demo hosts workflow

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -90,7 +90,8 @@ jobs:
           set -euo pipefail
           if kubectl -n "$NAMESPACE" get ingress midpoint >/dev/null 2>&1; then
             echo "Patching existing midPoint Ingress host -> ${MP_HOST}"
-            kubectl -n "$NAMESPACE" patch ingress midpoint --type=json               -p="[{'op':'replace','path':'/spec/rules/0/host','value':'${MP_HOST}'}]"
+            PATCH_PAYLOAD=$(printf '[{"op":"replace","path":"/spec/rules/0/host","value":"%s"}]' "${MP_HOST}")
+            kubectl -n "$NAMESPACE" patch ingress midpoint --type=json -p "${PATCH_PAYLOAD}"
           else
             echo "Creating midPoint Ingress with host ${MP_HOST}"
             cat <<EOF | kubectl -n "$NAMESPACE" apply -f -


### PR DESCRIPTION
## Summary
- generate the JSON patch for the midPoint ingress using printf instead of an inline literal
- avoid the malformed quoting that broke the workflow YAML parser

## Testing
- not run (workflow syntax fix)


------
https://chatgpt.com/codex/tasks/task_e_68cf1aa69be8832b8a479164f630fdab