### PR TITLE
Fix YAML indentation in configure demo hosts workflow

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -90,30 +90,30 @@ jobs:
           set -euo pipefail
           if kubectl -n "$NAMESPACE" get ingress midpoint >/dev/null 2>&1; then
             echo "Patching existing midPoint Ingress host -> ${MP_HOST}"
-            kubectl -n "$NAMESPACE" patch ingress midpoint --type=json               -p="[{'op':'replace','path':'/spec/rules/0/host','value':'${MP_HOST}'}]"
+            kubectl -n "$NAMESPACE" patch ingress midpoint --type=json -p="[{'op':'replace','path':'/spec/rules/0/host','value':'${MP_HOST}'}]"
           else
             echo "Creating midPoint Ingress with host ${MP_HOST}"
             cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: midpoint
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: ${MP_HOST}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: midpoint
-            port:
-              number: 8080
-EOF
+            apiVersion: networking.k8s.io/v1
+            kind: Ingress
+            metadata:
+              name: midpoint
+              annotations:
+                nginx.ingress.kubernetes.io/proxy-body-size: "16m"
+            spec:
+              ingressClassName: nginx
+              rules:
+              - host: ${MP_HOST}
+                http:
+                  paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                      service:
+                        name: midpoint
+                        port:
+                          number: 8080
+            EOF
           fi
           kubectl -n "$NAMESPACE" get ingress midpoint -o wide
 
@@ -127,26 +127,26 @@ EOF
           set -euo pipefail
           echo "Applying Keycloak public Ingress for host ${KC_HOST} -> ${SVC}:${PORT}"
           cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: rws-keycloak-public
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: ${KC_HOST}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: ${SVC}
-            port:
-              number: ${PORT}
-EOF
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: rws-keycloak-public
+            annotations:
+              nginx.ingress.kubernetes.io/proxy-body-size: "16m"
+          spec:
+            ingressClassName: nginx
+            rules:
+            - host: ${KC_HOST}
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: ${SVC}
+                      port:
+                        number: ${PORT}
+          EOF
           kubectl -n "$NAMESPACE" get ingress rws-keycloak-public -o wide
 
       - name: Smoke-test endpoints


### PR DESCRIPTION
## Summary
- ensure the heredoc manifests in the configure demo hosts workflow are indented so the YAML parses correctly
- tidy the kubectl patch command spacing while keeping the script formatting consistent

## Testing
- python - <<'PY'
import yaml
with open('.github/workflows/04_configure_demo_hosts.yml') as f:
    yaml.safe_load(f)
print('YAML parsed successfully')
PY

------
https://chatgpt.com/codex/tasks/task_e_68cf1d43addc832b939cd11df3ef21ca