### PR TITLE
Fix unbound KC_HOST in demo hosts workflow

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -73,9 +73,11 @@ jobs:
             kubectl -n ingress-nginx get svc ingress-nginx-controller -o yaml || true
             exit 1
           fi
+          KC_HOST="kc.${EXTERNAL_IP}.nip.io"
+          MP_HOST="mp.${EXTERNAL_IP}.nip.io"
           echo "EXTERNAL_IP=$EXTERNAL_IP" | tee -a $GITHUB_ENV
-          echo "KC_HOST=kc.${EXTERNAL_IP}.nip.io" | tee -a $GITHUB_ENV
-          echo "MP_HOST=mp.${EXTERNAL_IP}.nip.io" | tee -a $GITHUB_ENV
+          echo "KC_HOST=${KC_HOST}" | tee -a $GITHUB_ENV
+          echo "MP_HOST=${MP_HOST}" | tee -a $GITHUB_ENV
           echo "keycloak_url=http://kc.${EXTERNAL_IP}.nip.io" >> $GITHUB_OUTPUT
           echo "midpoint_url=http://mp.${EXTERNAL_IP}.nip.io/midpoint" >> $GITHUB_OUTPUT
           echo "Resolved EXTERNAL_IP: $EXTERNAL_IP"


### PR DESCRIPTION
## Summary
- define KC_HOST and MP_HOST variables before using them in the nip.io configuration workflow
- continue to export the resolved hostnames through $GITHUB_ENV for later steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf1f324084832b9374d04914c22e4b