### PR TITLE
Fix configure demo hosts workflow ingress generation

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -91,32 +91,17 @@ jobs:
         run: |
           set -euo pipefail
           if kubectl -n "$NAMESPACE" get ingress midpoint >/dev/null 2>&1; then
-            echo "Patching existing midPoint Ingress host -> ${MP_HOST}"
-            kubectl -n "$NAMESPACE" patch ingress midpoint --type=json -p="[{'op':'replace','path':'/spec/rules/0/host','value':'${MP_HOST}'}]"
+            echo "Reconciling existing midPoint Ingress host -> ${MP_HOST}"
           else
             echo "Creating midPoint Ingress with host ${MP_HOST}"
-            cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
-            apiVersion: networking.k8s.io/v1
-            kind: Ingress
-            metadata:
-              name: midpoint
-              annotations:
-                nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-            spec:
-              ingressClassName: nginx
-              rules:
-              - host: ${MP_HOST}
-                http:
-                  paths:
-                  - path: /
-                    pathType: Prefix
-                    backend:
-                      service:
-                        name: midpoint
-                        port:
-                          number: 8080
-            EOF
           fi
+          kubectl -n "$NAMESPACE" create ingress midpoint \
+            --class=nginx \
+            --rule="${MP_HOST}/=midpoint:8080" \
+            --annotation=nginx.ingress.kubernetes.io/proxy-body-size=16m \
+            --dry-run=client \
+            -o yaml \
+            | kubectl apply -f -
           kubectl -n "$NAMESPACE" get ingress midpoint -o wide
 
       - name: Create/Update Keycloak Ingress (public)
@@ -127,28 +112,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "Applying Keycloak public Ingress for host ${KC_HOST} -> ${SVC}:${PORT}"
-          cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
-          apiVersion: networking.k8s.io/v1
-          kind: Ingress
-          metadata:
-            name: rws-keycloak-public
-            annotations:
-              nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-          spec:
-            ingressClassName: nginx
-            rules:
-            - host: ${KC_HOST}
-              http:
-                paths:
-                - path: /
-                  pathType: Prefix
-                  backend:
-                    service:
-                      name: ${SVC}
-                      port:
-                        number: ${PORT}
-          EOF
+          echo "Reconciling Keycloak public Ingress for host ${KC_HOST} -> ${SVC}:${PORT}"
+          kubectl -n "$NAMESPACE" create ingress rws-keycloak-public \
+            --class=nginx \
+            --rule="${KC_HOST}/=${SVC}:${PORT}" \
+            --annotation=nginx.ingress.kubernetes.io/proxy-body-size=16m \
+            --dry-run=client \
+            -o yaml \
+            | kubectl apply -f -
           kubectl -n "$NAMESPACE" get ingress rws-keycloak-public -o wide
 
       - name: Smoke-test endpoints


### PR DESCRIPTION
## Summary
- replace heredoc manifest creation in the configure demo hosts workflow with kubectl create --dry-run pipelines
- avoid shell heredoc termination errors when reconciling Keycloak and midPoint ingresses

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cf204a121c832ba0a41970edb14d63