### PR TITLE
Quote workflow name to fix YAML parsing

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1,4 +1,4 @@
-name: 04 - Configure demo hosts (nip.io) & Ingresses
+name: "04 - Configure demo hosts (nip.io) & Ingresses"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- quote the workflow name so the ampersand is treated as text instead of a YAML anchor

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68cf2c4a269c832bbbe7dc99205ddd01