### PR TITLE
Fix Azure load balancer lookup by exporting node resource group

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -111,6 +111,7 @@ jobs:
             exit 1
           fi
           echo "NODE_RESOURCE_GROUP=${NODE_RG}" | tee -a "$GITHUB_ENV"
+          export NODE_RESOURCE_GROUP="${NODE_RG}"
 
           python3 <<'PY'
           import json


### PR DESCRIPTION
## Summary
- export the AKS node resource group before running the Python helper so Azure CLI commands receive the correct scope

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cf34570468832b86416cdd63eb0402