### PR TITLE
Ensure ingress health probe responds OK

### DIFF
--- a/k8s/addons/ingress-nginx/application.yaml
+++ b/k8s/addons/ingress-nginx/application.yaml
@@ -16,7 +16,15 @@ spec:
       releaseName: ingress-nginx
       values: |
         controller:
+          config:
+            server-snippet: |
+              location = /healthz {
+                access_log off;
+                return 200;
+              }
           service:
+            annotations:
+              service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
             type: LoadBalancer
   syncPolicy:
     automated:


### PR DESCRIPTION
## Summary
- configure the ingress-nginx service so Azure uses the /healthz probe path
- add an nginx server snippet that returns 200 for /healthz to keep the load balancer backend healthy

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68cfad8d6554832b9654bfcfc3d2a24d