### PR TITLE
Fix missing fi in smoke-test endpoints workflow step

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1750,6 +1750,7 @@ jobs:
                     --query "[?ipAddress=='${EXTERNAL_IP}'].{name:name, ip:ipAddress, sku:sku.name, provisioningState:provisioningState}" \
                     -o table || true
                 fi
+              fi
               exit 1
             fi
             sleep "$sleep_seconds"


### PR DESCRIPTION
## Summary
- add the missing `fi` in the smoke-test endpoints step so the Azure load balancer diagnostics block closes correctly

## Testing
- python - <<'PY'
import yaml
import subprocess
with open('.github/workflows/04_configure_demo_hosts.yml') as fh:
    data = yaml.safe_load(fh)
for step in data['jobs']['configure']['steps']:
    if isinstance(step, dict) and 'run' in step:
        subprocess.run(['bash','-n'], input=step['run'], text=True, check=True)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cfb0393b8c832b97818ce9aad0f7ad