### PR TITLE
Fix indentation in load balancer health diagnostics script

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1375,16 +1375,16 @@ jobs:
                           return {}
 
                       if poll_status >= 400:
-                  if description:
-                      print(
-                          f"  Polling {description} failed with status {poll_status}",
-                          file=sys.stderr,
-                      )
-                  else:
-                      print(
-                          f"  Polling Azure operation failed with status {poll_status}",
-                          file=sys.stderr,
-                      )
+                          if description:
+                              print(
+                                  f"  Polling {description} failed with status {poll_status}",
+                                  file=sys.stderr,
+                              )
+                          else:
+                              print(
+                                  f"  Polling Azure operation failed with status {poll_status}",
+                                  file=sys.stderr,
+                              )
                           if poll_text:
                               print(poll_text, file=sys.stderr)
                           return None


### PR DESCRIPTION
## Summary
- fix the indentation of the Azure load balancer health diagnostics helper embedded in `04_configure_demo_hosts.yml` so the smoke-test step no longer raises `IndentationError`

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfb73b80cc832b8a8266340d4fed25