### PR TITLE
Fix missing imports in load balancer health dump

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1149,10 +1149,15 @@ jobs:
               if [ -n "${NODE_RESOURCE_GROUP:-}" ] && [ -n "${LB_NAME:-}" ] && [ -n "${LB_TARGET_POOLS:-}" ] && [ -n "${LB_TARGET_RULES:-}" ]; then
                 echo "Azure load balancer backend health (final observation):"
                 python3 <<'PY'
+          import datetime
+          import email.utils
           import json
           import os
           import subprocess
           import sys
+          import time
+          import urllib.error
+          import urllib.request
 
           node_rg = os.environ.get("NODE_RESOURCE_GROUP", "").strip()
           lb_name = os.environ.get("LB_NAME", "").strip()


### PR DESCRIPTION
## Summary
- add the missing datetime, email, time, and urllib imports to the Azure load balancer health dump helper in the smoke test workflow to avoid NameError exceptions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfba5a1788832b82daa55d05a7cfe0