### PR TITLE
Add Keycloak fallback URLs to HTTP availability check

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1159,10 +1159,21 @@ jobs:
           attempts=18
           sleep_seconds=15
 
+          # Depending on the Keycloak distribution/operator defaults the HTTP endpoints
+          # may be exposed directly at "/" or under the historical "/auth" context
+          # path. Try both the seeded "rws" realm and the built-in master realm so
+          # the smoke test succeeds regardless of which base path the controller
+          # currently advertises.
           keycloak_urls=(
             "http://${KC_HOST}"
-            "http://${KC_HOST}/realms/master"
+            "http://${KC_HOST}/realms/rws/.well-known/openid-configuration"
+            "http://${KC_HOST}/realms/rws"
             "http://${KC_HOST}/realms/master/.well-known/openid-configuration"
+            "http://${KC_HOST}/realms/master"
+            "http://${KC_HOST}/auth/realms/rws/.well-known/openid-configuration"
+            "http://${KC_HOST}/auth/realms/rws"
+            "http://${KC_HOST}/auth/realms/master/.well-known/openid-configuration"
+            "http://${KC_HOST}/auth/realms/master"
           )
 
           midpoint_urls=(


### PR DESCRIPTION
## Summary
- extend the Keycloak smoke-test URL list so the workflow also tries the seeded rws realm
- include fallbacks for deployments that expose Keycloak under the legacy /auth context

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfc097aab8832bb9cc3c688a3cef71