### PR TITLE
Disable Keycloak strict hostname checks for nip.io ingress

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -15,6 +15,13 @@ spec:
       value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable
     - name: health-enabled
       value: "true"
+    # Allow the demo ingress to terminate HTTP without Keycloak rejecting the
+    # host/scheme. The nip.io address changes every time the AKS load balancer
+    # IP changes, so keep hostname checks disabled explicitly at runtime.
+    - name: hostname-strict
+      value: "false"
+    - name: hostname-strict-https
+      value: "false"
     # Pin a safe default features list so the operator stops appending the
     # removed "health" toggle. The 26.x operator still injects its defaults
     # whenever the enabled list is empty, which makes the pod exit with


### PR DESCRIPTION
## Summary
- ensure the Keycloak CR passes `--hostname-strict=false` and `--hostname-strict-https=false` so nip.io ingress hosts are accepted when the load balancer IP changes
- document the rationale inline so future updates keep the explicit hostname guards in place

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfcb66c7d0832bb16281f09400bb30