### PR TITLE
Fix indentation in demo hosts workflow

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1114,21 +1114,21 @@ jobs:
           fi
           selector=$(kubectl -n "$NAMESPACE" get svc "$SVC" -o json \
             | python3 <<'PY'
-import json
-import sys
+          import json
+          import sys
 
-svc = json.load(sys.stdin)
-selector = svc.get("spec", {}).get("selector") or {}
-parts = []
-for key, value in selector.items():
-    if not key:
-        continue
-    value_str = "" if value is None else str(value)
-    if not value_str:
-        continue
-    parts.append(f"{key}={value_str}")
-print(",".join(parts))
-PY
+          svc = json.load(sys.stdin)
+          selector = svc.get("spec", {}).get("selector") or {}
+          parts = []
+          for key, value in selector.items():
+              if not key:
+                  continue
+              value_str = "" if value is None else str(value)
+              if not value_str:
+                  continue
+              parts.append(f"{key}={value_str}")
+          print(",".join(parts))
+          PY
           )
           selector=$(tr -d '\r\n' <<<"${selector}")
           if [ -z "${selector}" ]; then


### PR DESCRIPTION
## Summary
- fix the heredoc indentation for the Keycloak service selector check so the workflow YAML parses correctly

## Testing
- Not run (yamllint not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfd4e98d94832bb15aa4b015404773