### PR TITLE
Fix Keycloak ingress workflow selector parsing

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1122,27 +1122,24 @@ jobs:
             kubectl -n "$NAMESPACE" get svc "$SVC" -o yaml || true
             exit 1
           fi
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "ERROR: jq is required to compute the Keycloak selector." >&2
+            exit 1
+          fi
           selector=$(
-            SVC_JSON="${svc_json}" python3 -c '
-import json
-import os
-
-raw_json = os.environ.get("SVC_JSON", "").strip()
-if not raw_json:
-    raise SystemExit("Service JSON payload is empty")
-
-svc = json.loads(raw_json)
-selector = svc.get("spec", {}).get("selector") or {}
-parts = []
-for key, value in selector.items():
-    if not key:
-        continue
-    value_str = "" if value is None else str(value)
-    if not value_str:
-        continue
-    parts.append(f"{key}={value_str}")
-print(",".join(parts))
-'
+            kubectl -n "$NAMESPACE" get svc "$SVC" -o json |
+            jq -r '
+              (.spec.selector // {})
+              | to_entries
+              | map(
+                  select(
+                    (.key // "") != ""
+                    and (((.value // "") | tostring) | length) > 0
+                  )
+                )
+              | map("\(.key)=\(.value // "")")
+              | join(",")
+            '
           )
           selector=$(tr -d '\r\n' <<<"${selector}")
           if [ -z "${selector}" ]; then


### PR DESCRIPTION
## Summary
- fix the Keycloak ingress workflow YAML indentation issue by replacing the inline Python snippet
- compute the service selector using jq and ensure the workflow fails if jq is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfe2dc70a8832b9388cf3c1be0d80a