### PR TITLE
Fix Keycloak selector extraction script quoting

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1123,26 +1123,26 @@ jobs:
             exit 1
           fi
           selector=$(
-            SVC_JSON="${svc_json}" python3 -c '
-              import json
-              import os
+            SVC_JSON="${svc_json}" python3 <<'PY'
+            import json
+            import os
 
-              raw_json = os.environ.get("SVC_JSON", "").strip()
-              if not raw_json:
-                  raise SystemExit("Service JSON payload is empty")
+            raw_json = os.environ.get("SVC_JSON", "").strip()
+            if not raw_json:
+                raise SystemExit("Service JSON payload is empty")
 
-              svc = json.loads(raw_json)
-              selector = svc.get("spec", {}).get("selector") or {}
-              parts = []
-              for key, value in selector.items():
-                  if not key:
-                      continue
-                  value_str = "" if value is None else str(value)
-                  if not value_str:
-                      continue
-                  parts.append(f"{key}={value_str}")
-              print(",".join(parts))
-            '
+            svc = json.loads(raw_json)
+            selector = svc.get("spec", {}).get("selector") or {}
+            parts = []
+            for key, value in selector.items():
+                if not key:
+                    continue
+                value_str = "" if value is None else str(value)
+                if not value_str:
+                    continue
+                parts.append(f"{key}={value_str}")
+            print(",".join(parts))
+            PY
           )
           selector=$(tr -d '\r\n' <<<"${selector}")
           if [ -z "${selector}" ]; then


### PR DESCRIPTION
## Summary
- switch the Keycloak selector extraction step to use a heredoc Python snippet so the YAML parser no longer chokes on inline quoting
- keep the readiness gate behavior the same while ensuring the script stays within the bash run block

## Testing
- `python3 - <<'PY'
import yaml
with open('.github/workflows/04_configure_demo_hosts.yml') as f:
    yaml.safe_load(f)
print('ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68cffb7bc1fc832b89565df25dc97ada