### PR TITLE
Fix heredoc indentation in Keycloak ingress workflow

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1142,7 +1142,7 @@ jobs:
                     continue
                 parts.append(f"{key}={value_str}")
             print(",".join(parts))
-            PY
+          PY
           )
           selector=$(tr -d '\r\n' <<<"${selector}")
           if [ -z "${selector}" ]; then


### PR DESCRIPTION
## Summary
- Align the heredoc terminator in the Keycloak ingress workflow so the command substitution closes correctly at runtime.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d013bb264c832b8da83c722f530203