### PR TITLE
Fix heredoc indentation in Keycloak ingress step

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1124,25 +1124,25 @@ jobs:
           fi
           selector=$(
             SVC_JSON="${svc_json}" python3 <<'PY'
-            import json
-            import os
+          import json
+          import os
 
-            raw_json = os.environ.get("SVC_JSON", "").strip()
-            if not raw_json:
-                raise SystemExit("Service JSON payload is empty")
+          raw_json = os.environ.get("SVC_JSON", "").strip()
+          if not raw_json:
+              raise SystemExit("Service JSON payload is empty")
 
-            svc = json.loads(raw_json)
-            selector = svc.get("spec", {}).get("selector") or {}
-            parts = []
-            for key, value in selector.items():
-                if not key:
-                    continue
-                value_str = "" if value is None else str(value)
-                if not value_str:
-                    continue
-                parts.append(f"{key}={value_str}")
-            print(",".join(parts))
-            PY
+          svc = json.loads(raw_json)
+          selector = svc.get("spec", {}).get("selector") or {}
+          parts = []
+          for key, value in selector.items():
+              if not key:
+                  continue
+              value_str = "" if value is None else str(value)
+              if not value_str:
+                  continue
+              parts.append(f"{key}={value_str}")
+          print(",".join(parts))
+          PY
           )
           selector=$(tr -d '\r\n' <<<"${selector}")
           if [ -z "${selector}" ]; then


### PR DESCRIPTION
## Summary
- remove extra indentation from the embedded Python snippet in the Keycloak ingress step so the heredoc terminator is recognised
- keep the selector extraction logic intact while ensuring the workflow runs the Python code without syntax errors

## Testing
- python - <<'PY' import yaml; yaml.safe_load(open('.github/workflows/04_configure_demo_hosts.yml'))


------
https://chatgpt.com/codex/tasks/task_e_68d013bb264c832b8da83c722f530203