### PR TITLE
Fix indentation in midPoint ingress heredoc

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1091,27 +1091,27 @@ jobs:
           fi
           # Render the Ingress with pathType Prefix so nested routes like /midpoint remain routable.
           kubectl apply -f - <<EOF
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: midpoint
-  namespace: ${NAMESPACE}
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: 16m
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: ${MP_HOST}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
             name: midpoint
-            port:
-              number: 8080
-EOF
+            namespace: ${NAMESPACE}
+            annotations:
+              nginx.ingress.kubernetes.io/proxy-body-size: 16m
+          spec:
+            ingressClassName: nginx
+            rules:
+            - host: ${MP_HOST}
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: midpoint
+                      port:
+                        number: 8080
+          EOF
           kubectl -n "$NAMESPACE" get ingress midpoint -o wide
 
       - name: Create/Update Keycloak Ingress (public)


### PR DESCRIPTION
## Summary
- ensure the heredoc that applies the midPoint ingress is indented within the workflow's run block so the YAML parses correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d01e194878832b9fc3a1415e556595