### PR TITLE
Fix Python split quoting in demo hosts workflow

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -196,7 +196,7 @@ jobs:
               sys.exit(1)
           
           ip_config_id = ip_config_ids[0]
-          parts = [segment for segment in ip_config_id.split('/') if segment]
+          parts = [segment for segment in ip_config_id.split("/") if segment]
           
           try:
               lb_index = parts.index("loadBalancers")


### PR DESCRIPTION
## Summary
- update the inline Python in the demo hosts workflow to split the load balancer resource id using double quotes so the shell does not strip them

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d023aa4ed8832ba88de0ee940ab51f