### PR TITLE
Fix midPoint ingress heredoc piping

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -1090,7 +1090,7 @@ jobs:
             echo "Creating midPoint Ingress with host ${MP_HOST}"
           fi
           # Render the Ingress with pathType Prefix so nested routes like /midpoint remain routable.
-          python3 <<'PY'
+          python3 <<'PY' | kubectl apply -f -
           import os
           import textwrap
 
@@ -1119,7 +1119,7 @@ jobs:
                         number: 8080
           ''')
           print(manifest, end="")
-          PY | kubectl apply -f -
+          PY
           kubectl -n "$NAMESPACE" get ingress midpoint -o wide
 
       - name: Create/Update Keycloak Ingress (public)


### PR DESCRIPTION
## Summary
- pipe the Python-rendered midPoint ingress manifest directly to `kubectl apply` so the heredoc terminator stays syntactically correct

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d033b73ab4832bb09b35353fa2fdae