### PR TITLE
Simplify Keycloak realm import kustomization

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -65,38 +65,3 @@ spec:
     limits:
       cpu: "1"
       memory: "2Gi"
----
-apiVersion: k8s.keycloak.org/v2alpha1
-kind: KeycloakRealmImport
-metadata:
-  name: rws-realm-import
-  namespace: iam
-  annotations:
-    iam.demo/realm-config-version: "1"
-spec:
-  keycloakCRName: rws-keycloak
-  realm:
-    id: rws
-    realm: rws
-    displayName: RWS Demo
-    enabled: true
-    registrationAllowed: false
-    loginWithEmailAllowed: true
-    resetPasswordAllowed: true
-    sslRequired: none
-    webAuthnPolicyRpEntityName: "RWS Demo"
-    webAuthnPolicyUserVerificationRequirement: "required"
-    webAuthnPolicyCreateTimeout: 120000
-    webAuthnPolicyAvoidSameAuthenticatorRegister: true
-    clients:
-      - clientId: rws-midpoint
-        name: rws-midpoint
-        protocol: openid-connect
-        publicClient: true
-        directAccessGrantsEnabled: true
-        standardFlowEnabled: true
-        redirectUris:
-          - "http://*/midpoint/*"
-        webOrigins:
-          - "*"
-

--- a/k8s/apps/keycloak/rws-realm.yaml
+++ b/k8s/apps/keycloak/rws-realm.yaml
@@ -3,7 +3,10 @@ kind: KeycloakRealmImport
 metadata:
   name: rws-realm-import
   namespace: iam
+  annotations:
+    iam.demo/realm-config-version: "1"
 spec:
+  keycloakCRName: rws-keycloak
   realm:
     id: rws
     realm: rws

--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -2,26 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - keycloak/keycloak.yaml
+  - keycloak/rws-realm.yaml
   - keycloak/ingress.yaml
   - midpoint
-patches:
-  - path: keycloak/rws-realm.yaml
-    target:
-      kind: KeycloakRealmImport
-      name: rws-realm-import
-configMapGenerator:
-  - name: rws-realm-import-checksum
-    files:
-      - realm.yaml=keycloak/rws-realm.yaml
-    options:
-      disableNameSuffixHash: false
-      annotations:
-        argocd.argoproj.io/sync-options: Skip=true
-vars:
-  - name: REALM_CHECKSUM
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: rws-realm-import-checksum
-    fieldref:
-      fieldpath: metadata.name


### PR DESCRIPTION
## Summary
- split the KeycloakRealmImport definition into its own manifest to avoid duplication
- trim unused kustomize config map/variable boilerplate now that the realm import is a standalone resource

## Testing
- kustomize build k8s/apps *(fails: kustomize not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d050589880832ba5433b2a28992daf