### PR TITLE
Refactor scripts and midpoint env setup

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -383,6 +383,9 @@ spec:
               rm -f "${info_log}"
 
               echo "midPoint repository bootstrap complete"
+          envFrom:
+            - configMapRef:
+                name: midpoint-env
           env:
             - name: MIDPOINT_JDBC_URL
               value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=disable
@@ -390,28 +393,6 @@ spec:
               value: /var/run/secrets/midpoint-db-app/username
             - name: MIDPOINT_DB_PASSWORD_FILE
               value: /var/run/secrets/midpoint-db-app/password
-            - name: MP_NO_ENV_COMPAT
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_database
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_jdbcUrl
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_hibernateHbm2ddl
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_initializationFailTimeout
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_missingSchemaAction
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_upgradeableSchemaAction
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_jdbcUsername
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_jdbcPassword
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_username
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_password
-              value: "1"
           volumeMounts:
             - name: midpoint-home
               mountPath: /opt/midpoint/var
@@ -427,35 +408,16 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: midpoint-env
           env:
             - name: MP_SET_midpoint_administrator_initialPassword_FILE
               value: /var/run/secrets/midpoint-admin/password
-            - name: MP_NO_ENV_COMPAT
-              value: "1"
             - name: MP_MEM_INIT
               value: "768M"
             - name: MP_MEM_MAX
               value: "1536M"
-            - name: MP_UNSET_midpoint_repository_database
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_jdbcUrl
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_hibernateHbm2ddl
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_initializationFailTimeout
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_missingSchemaAction
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_upgradeableSchemaAction
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_jdbcUsername
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_jdbcPassword
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_username
-              value: "1"
-            - name: MP_UNSET_midpoint_repository_password
-              value: "1"
           volumeMounts:
             - name: midpoint-home
               mountPath: /opt/midpoint/var

--- a/k8s/apps/midpoint/kustomization.yaml
+++ b/k8s/apps/midpoint/kustomization.yaml
@@ -13,3 +13,18 @@ configMapGenerator:
       - config.xml
     options:
       disableNameSuffixHash: true
+  - name: midpoint-env
+    literals:
+      - MP_NO_ENV_COMPAT=1
+      - MP_UNSET_midpoint_repository_database=1
+      - MP_UNSET_midpoint_repository_jdbcUrl=1
+      - MP_UNSET_midpoint_repository_hibernateHbm2ddl=1
+      - MP_UNSET_midpoint_repository_initializationFailTimeout=1
+      - MP_UNSET_midpoint_repository_missingSchemaAction=1
+      - MP_UNSET_midpoint_repository_upgradeableSchemaAction=1
+      - MP_UNSET_midpoint_repository_jdbcUsername=1
+      - MP_UNSET_midpoint_repository_jdbcPassword=1
+      - MP_UNSET_midpoint_repository_username=1
+      - MP_UNSET_midpoint_repository_password=1
+    options:
+      disableNameSuffixHash: true


### PR DESCRIPTION
## Summary
- refactor the demo host configuration script to reuse ingress rendering and generate smoke-test URLs programmatically
- introduce reusable helpers in wait_for_apps to trim repeated kubectl diagnostics
- centralize shared midPoint MP_* environment variables in a ConfigMap referenced by envFrom

## Testing
- shellcheck scripts/configure_demo_hosts.sh scripts/wait_for_apps.sh *(fails: shellcheck not available in container)*
- kustomize build k8s/apps *(fails: kustomize not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d050589880832ba5433b2a28992daf