### PR TITLE
Ensure ingress patches carry class name

### DIFF
--- a/k8s/apps/keycloak/ingress-host-patch.yaml
+++ b/k8s/apps/keycloak/ingress-host-patch.yaml
@@ -4,5 +4,6 @@ metadata:
   name: rws-keycloak-public
   namespace: iam
 spec:
+  ingressClassName: nginx
   rules:
     - host: kc.132.220.29.66.nip.io

--- a/k8s/apps/midpoint/ingress-host-patch.yaml
+++ b/k8s/apps/midpoint/ingress-host-patch.yaml
@@ -4,5 +4,6 @@ metadata:
   name: midpoint
   namespace: iam
 spec:
+  ingressClassName: nginx
   rules:
     - host: mp.132.220.29.66.nip.io


### PR DESCRIPTION
## Summary
- add the ingressClassName field to the Keycloak and midPoint ingress host patches so they track the detected controller class

## Testing
- kustomize build k8s/apps | kubeconform --strict --ignore-missing-schemas --summary

------
https://chatgpt.com/codex/tasks/task_e_68d0ea4681c0832bb086c68b6b3f2d6e