### PR TITLE
Remove Keycloak legacy /auth base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 
 - Get the external IP of **ingress-nginx** (the workflow prints it; or: `kubectl -n ingress-nginx get svc ingress-nginx-controller`).
 - Keycloak is exposed through the operator-managed service `rws-keycloak-service`; check it with `kubectl -n iam get svc rws-keycloak-service` if you need the cluster IP before Ingress is ready.
-- Open Keycloak: `http://kc.<EXTERNAL-IP>.nip.io/auth` (admin user and password are in secret `rws-keycloak-initial-admin` created by operator)
-  - The deployment restores Keycloak's legacy `/auth` base path so older clients, including midPoint's built-in Keycloak integration, reach the realm endpoints without 404s.
+- Open Keycloak: `http://kc.<EXTERNAL-IP>.nip.io/` (admin user and password are in secret `rws-keycloak-initial-admin` created by operator)
+  - Keycloak now serves from the default root context, matching the upstream 26.x images. Drop any legacy `/auth` prefixes from bookmarks or client configurations.
   - The Keycloak Operator exposes HTTP on service **`rws-keycloak-service`** (note the `-service` suffix). Use `kubectl -n iam get svc` to list the generated service names instead of querying `rws-keycloak` directly.
 - Open midPoint: `http://mp.<EXTERNAL-IP>.nip.io/midpoint`
   - Login: `administrator` / the `MIDPOINT_ADMIN_PASSWORD` you set

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -15,11 +15,6 @@ spec:
       value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable
     - name: health-enabled
       value: "true"
-    # Restore the legacy /auth base path so clients that still expect it (for
-    # example midPoint's built-in Keycloak integration) resolve the realm
-    # endpoints without returning a 404 from Keycloak 26.
-    - name: http-relative-path
-      value: /auth
     # Allow the demo ingress to terminate HTTP without Keycloak rejecting the
     # host/scheme. The nip.io address changes every time the AKS load balancer
     # IP changes, so keep hostname checks disabled explicitly at runtime.

--- a/scripts/configure_demo_hosts.sh
+++ b/scripts/configure_demo_hosts.sh
@@ -362,6 +362,8 @@ smoke_test() {
     "/realms/master"
   )
 
+  # Probe the default root context first; fall back to the legacy /auth base
+  # path if an older deployment still uses it.
   for prefix in "" "/auth"; do
     for keycloak_path in "${keycloak_paths[@]}"; do
       keycloak_urls+=("http://${KC_HOST}${prefix}${keycloak_path}")
@@ -405,7 +407,7 @@ main() {
   smoke_test
 
   log "✅ Configuration complete."
-  log "Keycloak URL: http://${KC_HOST}/auth"
+  log "Keycloak URL: http://${KC_HOST}/"
   log "midPoint URL: http://${MP_HOST}/midpoint"
 }
 


### PR DESCRIPTION
## Summary
- stop configuring the Keycloak deployment with the deprecated /auth relative path so the service uses the default context root
- refresh the Keycloak availability probe and README guidance to reference the root URL while keeping a legacy /auth fallback for older clusters

## Testing
- bash -n scripts/configure_demo_hosts.sh

------
https://chatgpt.com/codex/tasks/task_e_68d0f245413c832ba2b2d751bacae41e