### PR TITLE
Ensure ingress patches retain backend paths

### DIFF
--- a/k8s/apps/keycloak/ingress-host-patch.yaml
+++ b/k8s/apps/keycloak/ingress-host-patch.yaml
@@ -7,3 +7,12 @@ spec:
   ingressClassName: nginx
   rules:
     - host: kc.132.220.29.66.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rws-keycloak-service
+                port:
+                  number: 8080

--- a/k8s/apps/midpoint/ingress-host-patch.yaml
+++ b/k8s/apps/midpoint/ingress-host-patch.yaml
@@ -7,3 +7,12 @@ spec:
   ingressClassName: nginx
   rules:
     - host: mp.132.220.29.66.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: midpoint
+                port:
+                  number: 8080

--- a/scripts/configure_demo_hosts.sh
+++ b/scripts/configure_demo_hosts.sh
@@ -75,6 +75,8 @@ write_ingress_patch() {
   local patch_file="$2"
   local ingress_name="$3"
   local host="$4"
+  local service_name="$5"
+  local service_port="$6"
 
   log "Updating ${label} ingress patch at ${patch_file} with host ${host}..."
   cat <<EOF >"${patch_file}"
@@ -87,6 +89,15 @@ spec:
   ingressClassName: ${INGRESS_CLASS_NAME}
   rules:
     - host: ${host}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ${service_name}
+                port:
+                  number: ${service_port}
 EOF
   log "${label} ingress patch updated. Commit and push this change so Argo CD reconciles the ingress host."
 }
@@ -136,8 +147,8 @@ detect_ingress_class() {
 }
 
 update_gitops_manifests() {
-  write_ingress_patch "Keycloak" "${KEYCLOAK_INGRESS_PATCH_FILE}" "${KEYCLOAK_INGRESS_NAME}" "${KC_HOST}"
-  write_ingress_patch "midPoint" "${MIDPOINT_INGRESS_PATCH_FILE}" "${MIDPOINT_INGRESS_NAME}" "${MP_HOST}"
+  write_ingress_patch "Keycloak" "${KEYCLOAK_INGRESS_PATCH_FILE}" "${KEYCLOAK_INGRESS_NAME}" "${KC_HOST}" "${KEYCLOAK_SERVICE_NAME}" "${KEYCLOAK_SERVICE_PORT}"
+  write_ingress_patch "midPoint" "${MIDPOINT_INGRESS_PATCH_FILE}" "${MIDPOINT_INGRESS_NAME}" "${MP_HOST}" "${MIDPOINT_SERVICE_NAME}" "${MIDPOINT_SERVICE_PORT}"
 }
 
 resolve_ingress_ip() {


### PR DESCRIPTION
## Summary
- update the demo host configurator so the generated ingress patches include backend routing details
- embed the backend path configuration in the Keycloak and midPoint ingress host patches so Argo CD preserves service wiring

## Testing
- bash -n scripts/configure_demo_hosts.sh

------
https://chatgpt.com/codex/tasks/task_e_68d0f7396428832bbf110bc066c68e8a