### PR TITLE
Remove midpoint placeholder secret manifest

### DIFF
--- a/k8s/apps/midpoint/kustomization.yaml
+++ b/k8s/apps/midpoint/kustomization.yaml
@@ -4,7 +4,6 @@ namespace: iam
 
 resources:
   - deployment.yaml
-  - precreate.yaml
   - ingress.yaml
 
 configMapGenerator:

--- a/k8s/apps/midpoint/precreate.yaml
+++ b/k8s/apps/midpoint/precreate.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: midpoint-admin
-  namespace: iam
-type: Opaque
-stringData:
-  password: CHANGEME


### PR DESCRIPTION
## Summary
- drop the midpoint admin placeholder secret manifest so Argo CD no longer syncs the CHANGEME password
- update the midpoint kustomization to stop referencing the deleted secret and rely on the workflow-created secret instead

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d11ee83668832b8179ca6eaf7bbac4