### PR TITLE
Simplify ingress host patches with JSON6902

### DIFF
--- a/k8s/apps/keycloak/ingress-host-patch.yaml
+++ b/k8s/apps/keycloak/ingress-host-patch.yaml
@@ -1,18 +1,6 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: rws-keycloak-public
-  namespace: iam
-spec:
-  ingressClassName: nginx
-  rules:
-    - host: kc.132.220.29.66.nip.io
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: rws-keycloak-service
-                port:
-                  number: 8080
+- op: add
+  path: /spec/ingressClassName
+  value: nginx
+- op: add
+  path: /spec/rules/0/host
+  value: kc.132.220.29.66.nip.io

--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -6,6 +6,18 @@ resources:
   - keycloak/ingress.yaml
   - midpoint
 
-patchesStrategicMerge:
-  - keycloak/ingress-host-patch.yaml
-  - midpoint/ingress-host-patch.yaml
+patchesJson6902:
+  - target:
+      group: networking.k8s.io
+      version: v1
+      kind: Ingress
+      name: rws-keycloak-public
+      namespace: iam
+    path: keycloak/ingress-host-patch.yaml
+  - target:
+      group: networking.k8s.io
+      version: v1
+      kind: Ingress
+      name: midpoint
+      namespace: iam
+    path: midpoint/ingress-host-patch.yaml

--- a/k8s/apps/midpoint/ingress-host-patch.yaml
+++ b/k8s/apps/midpoint/ingress-host-patch.yaml
@@ -1,18 +1,6 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: midpoint
-  namespace: iam
-spec:
-  ingressClassName: nginx
-  rules:
-    - host: mp.132.220.29.66.nip.io
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: midpoint
-                port:
-                  number: 8080
+- op: add
+  path: /spec/ingressClassName
+  value: nginx
+- op: add
+  path: /spec/rules/0/host
+  value: mp.132.220.29.66.nip.io

--- a/scripts/configure_demo_hosts.sh
+++ b/scripts/configure_demo_hosts.sh
@@ -73,31 +73,16 @@ EOF
 write_ingress_patch() {
   local label="$1"
   local patch_file="$2"
-  local ingress_name="$3"
-  local host="$4"
-  local service_name="$5"
-  local service_port="$6"
+  local host="$3"
 
   log "Updating ${label} ingress patch at ${patch_file} with host ${host}..."
   cat <<EOF >"${patch_file}"
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ${ingress_name}
-  namespace: ${NAMESPACE}
-spec:
-  ingressClassName: ${INGRESS_CLASS_NAME}
-  rules:
-    - host: ${host}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: ${service_name}
-                port:
-                  number: ${service_port}
+- op: add
+  path: /spec/ingressClassName
+  value: ${INGRESS_CLASS_NAME}
+- op: add
+  path: /spec/rules/0/host
+  value: ${host}
 EOF
   log "${label} ingress patch updated. Commit and push this change so Argo CD reconciles the ingress host."
 }
@@ -147,8 +132,8 @@ detect_ingress_class() {
 }
 
 update_gitops_manifests() {
-  write_ingress_patch "Keycloak" "${KEYCLOAK_INGRESS_PATCH_FILE}" "${KEYCLOAK_INGRESS_NAME}" "${KC_HOST}" "${KEYCLOAK_SERVICE_NAME}" "${KEYCLOAK_SERVICE_PORT}"
-  write_ingress_patch "midPoint" "${MIDPOINT_INGRESS_PATCH_FILE}" "${MIDPOINT_INGRESS_NAME}" "${MP_HOST}" "${MIDPOINT_SERVICE_NAME}" "${MIDPOINT_SERVICE_PORT}"
+  write_ingress_patch "Keycloak" "${KEYCLOAK_INGRESS_PATCH_FILE}" "${KC_HOST}"
+  write_ingress_patch "midPoint" "${MIDPOINT_INGRESS_PATCH_FILE}" "${MP_HOST}"
 }
 
 resolve_ingress_ip() {


### PR DESCRIPTION
## Summary
- replace the ingress host overrides for Keycloak and midPoint with concise JSON6902 patches so the GitOps source no longer duplicates the full manifests
- update the configure_demo_hosts helper to write the new patch format while keeping the dynamic host detection logic intact

## Testing
- kubectl kustomize k8s/apps *(fails: kubectl not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d11ef7ea50832bb38d058b09251c78