### PR TITLE
Refactor demo host configuration for GitOps reconciliation

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -15,15 +15,6 @@ on:
         description: 'Namespace for IAM stack (Keycloak + midPoint)'
         required: true
         default: 'iam'
-      KEYCLOAK_SERVICE_NAME:
-        description: 'Keycloak Service name (check kubectl -n <ns> get svc)'
-        required: true
-        default: 'rws-keycloak-service'
-      KEYCLOAK_SERVICE_PORT:
-        description: 'Keycloak Service port (8080 for httpEnabled=true)'
-        required: true
-        default: '8080'
-
 permissions:
   id-token: write
   contents: write
@@ -52,11 +43,9 @@ jobs:
         shell: bash
         env:
           NAMESPACE_IAM: ${{ inputs.NAMESPACE_IAM }}
-          KEYCLOAK_SERVICE_NAME: ${{ inputs.KEYCLOAK_SERVICE_NAME }}
-          KEYCLOAK_SERVICE_PORT: ${{ inputs.KEYCLOAK_SERVICE_PORT }}
         run: |
           set -euo pipefail
-          bash scripts/configure_demo_hosts.sh
+          bash scripts/configure_demo_hosts.sh update
 
       - name: Commit ingress host patches
         shell: bash
@@ -65,12 +54,12 @@ jobs:
           KC_HOST_VALUE="${KC_HOST:-}"
           MP_HOST_VALUE="${MP_HOST:-}"
           BRANCH_REF="${GITHUB_REF:-}"
-          if git diff --quiet --exit-code -- k8s/apps/keycloak/ingress-host-patch.yaml k8s/apps/midpoint/ingress-host-patch.yaml; then
+          if git diff --quiet --exit-code -- k8s/apps/keycloak/hostname-patch.yaml k8s/apps/midpoint/ingress-host-patch.yaml; then
             echo "Ingress host patches already up to date; skipping commit."
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add k8s/apps/keycloak/ingress-host-patch.yaml k8s/apps/midpoint/ingress-host-patch.yaml
+            git add k8s/apps/keycloak/hostname-patch.yaml k8s/apps/midpoint/ingress-host-patch.yaml
             git commit -m "Update demo ingress hosts to ${KC_HOST_VALUE} and ${MP_HOST_VALUE}"
             if [[ "${BRANCH_REF}" == refs/heads/* ]]; then
               BRANCH_NAME="${BRANCH_REF#refs/heads/}"
@@ -79,6 +68,24 @@ jobs:
               echo "Ref ${BRANCH_REF} is not a branch; skipping push."
             fi
           fi
+
+      - name: Install Argo CD CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v argocd >/dev/null 2>&1; then
+            curl -sSL -o /tmp/argocd-linux-amd64 \
+              https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+            install -m 0755 /tmp/argocd-linux-amd64 /usr/local/bin/argocd
+          fi
+
+      - name: Sync Argo CD application and verify endpoints
+        shell: bash
+        env:
+          NAMESPACE_IAM: ${{ inputs.NAMESPACE_IAM }}
+        run: |
+          set -euo pipefail
+          bash scripts/configure_demo_hosts.sh verify
 
       - name: Summary
         shell: bash

--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 
 1. Run workflow **`04_configure_demo_hosts.yml`**.
 2. The helper script (`scripts/configure_demo_hosts.sh`) discovers the `ingress-nginx` load balancer address,
-   waits for the Keycloak and midPoint services to expose ready pods, updates the GitOps host patches
-   (`k8s/apps/keycloak/hostname-patch.yaml` and `k8s/apps/midpoint/ingress-host-patch.yaml`) with
-   `kc.<IP>.nip.io` and `mp.<IP>.nip.io`, applies them once so you can browse immediately, and lets the workflow
-   commit the patch files back to the repo. Argo CD now reconciles the dynamic hosts directly from Git instead
-   of relying on `ignoreDifferences` rules.
+   updates the GitOps host patches (`k8s/apps/keycloak/hostname-patch.yaml` and
+   `k8s/apps/midpoint/ingress-host-patch.yaml`) with `kc.<IP>.nip.io` and `mp.<IP>.nip.io`, and writes the
+   resolved URLs to the workflow outputs. The workflow commits the patch files back to the repository,
+   installs the Argo CD CLI, triggers a sync of the `apps` application with `argocd app sync --core`, waits for
+   the application to become healthy, and finally smoke-tests the Keycloak and midPoint endpoints to confirm the
+   GitOps reconciliation succeeded.
 
 ---
 


### PR DESCRIPTION
## Summary
- add update and verify modes to `configure_demo_hosts.sh` so the workflow patches Git and lets Argo CD reconcile instead of using imperative kubectl updates
- adjust `04_configure_demo_hosts` to run the new script modes, install the Argo CD CLI, and commit the correct patch file paths
- document the new GitOps reconciliation flow for demo ingress hosts in the README

## Testing
- bash -n scripts/configure_demo_hosts.sh


------
https://chatgpt.com/codex/tasks/task_e_68d1259c0210832bbc772048c416aaad