### PR TITLE
Remove imperative host configuration from helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 
 1. Run workflow **`04_configure_demo_hosts.yml`**.
 2. The helper script (`scripts/configure_demo_hosts.sh`) discovers the `ingress-nginx` load balancer address,
-   waits for the Keycloak and midPoint services to expose ready pods, updates the GitOps host patches
+   records the detected ingress class, and rewrites the GitOps host patches
    (`k8s/apps/keycloak/hostname-patch.yaml` and `k8s/apps/midpoint/ingress-host-patch.yaml`) with
-   `kc.<IP>.nip.io` and `mp.<IP>.nip.io`, applies them once so you can browse immediately, and lets the workflow
-   commit the patch files back to the repo. Argo CD now reconciles the dynamic hosts directly from Git instead
-   of relying on `ignoreDifferences` rules.
+   `kc.<IP>.nip.io` and `mp.<IP>.nip.io`. Commit those files after the workflow completes so Argo CD reconciles
+   the new hostnames straight from Git instead of relying on imperative `kubectl apply` calls.
 
 ---
 

--- a/scripts/configure_demo_hosts.sh
+++ b/scripts/configure_demo_hosts.sh
@@ -29,46 +29,8 @@ MIDPOINT_INGRESS_PATCH_FILE="${MIDPOINT_INGRESS_PATCH_FILE:-${PATCH_ROOT}/midpoi
 INGRESS_CLASS_NAME="${INGRESS_CLASS_NAME:-}"
 
 require_cmd kubectl
-require_cmd curl
 require_cmd jq
 require_cmd python3
-
-apply_ingress() {
-  local label="$1"
-  local name="$2"
-  local host="$3"
-  local service_name="$4"
-  local service_port="$5"
-
-  if [[ -z "${INGRESS_CLASS_NAME}" ]]; then
-    log "ERROR: Ingress class name is not set."
-    exit 1
-  fi
-
-  log "Reconciling ${label} ingress (host ${host})..."
-  cat <<EOF | kubectl apply -f -
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ${name}
-  namespace: ${NAMESPACE}
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
-spec:
-  ingressClassName: ${INGRESS_CLASS_NAME}
-  rules:
-    - host: ${host}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: ${service_name}
-                port:
-                  number: ${service_port}
-EOF
-}
 
 write_ingress_patch() {
   local label="$1"
@@ -147,15 +109,6 @@ detect_ingress_class() {
 update_gitops_manifests() {
   write_keycloak_hostname_patch "${KEYCLOAK_HOST_PATCH_FILE}" "${KC_HOST}"
   write_ingress_patch "midPoint" "${MIDPOINT_INGRESS_PATCH_FILE}" "${MP_HOST}"
-}
-
-patch_keycloak_hostname() {
-  local host="$1"
-
-  log "Reconciling Keycloak hostname ${host} on CR ${KEYCLOAK_CR_NAME}..."
-  kubectl -n "${NAMESPACE}" patch keycloaks.k8s.keycloak.org "${KEYCLOAK_CR_NAME}" \
-    --type merge \
-    --patch "$(printf '{"spec":{"hostname":{"hostname":"%s"}}}' "${host}")"
 }
 
 resolve_ingress_ip() {
@@ -244,191 +197,17 @@ wait_for_ingress_controller() {
   kubectl -n ingress-nginx rollout status deploy/ingress-nginx-controller --timeout=600s
 }
 
-wait_for_service_selector() {
-  local service_name="$1"
-  local attempts=30
-  local sleep_seconds=10
-  local svc_json selector
-
-  for attempt in $(seq 1 "${attempts}"); do
-    if ! svc_json=$(kubectl -n "${NAMESPACE}" get svc "${service_name}" -o json 2>/dev/null); then
-      log "Service ${service_name} not ready yet (attempt ${attempt}/${attempts}); retrying in ${sleep_seconds}s..."
-      sleep "${sleep_seconds}"
-      continue
-    fi
-
-    selector=$(jq -r '
-      .spec.selector // {} |
-      to_entries |
-      map(select(.value != null)) |
-      map(.key + "=" + .value) |
-      join(",")
-    ' <<<"${svc_json}" | tr -d '\r\n')
-
-    if [[ -n "${selector}" ]]; then
-      echo "${selector}"
-      return 0
-    fi
-
-    log "Service ${service_name} does not expose a selector yet (attempt ${attempt}/${attempts}); retrying..."
-    sleep "${sleep_seconds}"
-  done
-
-  log "ERROR: Timed out waiting for service ${service_name} to publish a pod selector."
-  kubectl -n "${NAMESPACE}" get svc "${service_name}" -o yaml || true
-  exit 1
-}
-
-wait_for_keycloak() {
-  local selector
-  selector=$(wait_for_service_selector "${KEYCLOAK_SERVICE_NAME}")
-  log "Keycloak service selector: ${selector}"
-
-  log "Waiting for Keycloak pods to become Ready..."
-  kubectl -n "${NAMESPACE}" wait --for=condition=ready pod -l "${selector}" --timeout=600s
-}
-
-wait_for_midpoint() {
-  log "Waiting for midPoint deployment ${MIDPOINT_SERVICE_NAME} to become available..."
-  kubectl -n "${NAMESPACE}" rollout status deploy/${MIDPOINT_SERVICE_NAME} --timeout=600s || true
-  if ! kubectl -n "${NAMESPACE}" get svc "${MIDPOINT_SERVICE_NAME}" >/dev/null 2>&1; then
-    log "WARNING: Service ${MIDPOINT_SERVICE_NAME} not found yet; continuing to ingress reconciliation."
-  fi
-}
-
-apply_ingresses() {
-  patch_keycloak_hostname "${KC_HOST}"
-  apply_ingress "midPoint" "${MIDPOINT_INGRESS_NAME}" "${MP_HOST}" "${MIDPOINT_SERVICE_NAME}" "${MIDPOINT_SERVICE_PORT}"
-  kubectl -n "${NAMESPACE}" get ingress -o wide || true
-}
-
-check_endpoint() {
-  local label="$1"
-  shift
-  local url status=1
-
-  for url in "$@"; do
-    [[ -n "${url}" ]] || continue
-    log "Probing ${label} at ${url}"
-
-    local headers_file body_file cookie_file http_code status_line curl_status
-    headers_file=$(mktemp)
-    body_file=$(mktemp)
-    cookie_file=$(mktemp)
-
-    # Capture headers and a small snippet of the body so we can surface
-    # the HTTP status code (and any proxy errors) without fighting pipefail.
-    if curl -sS --show-error --location --max-time 15 \
-      --cookie "${cookie_file}" --cookie-jar "${cookie_file}" \
-      --output "${body_file}" --dump-header "${headers_file}" \
-      "${url}"; then
-      status_line=$(head -n 1 "${headers_file}" | tr -d '\r\n')
-      http_code=$(awk 'NR==1 {print $2}' "${headers_file}" | tr -d '\r\n')
-
-      if [[ -n "${http_code}" && "${http_code}" =~ ^[0-9]+$ &&
-            "${http_code}" -ge 200 && "${http_code}" -lt 400 ]]; then
-        log "${label} responded via ${url}: ${status_line}"
-        status=0
-        rm -f "${headers_file}" "${body_file}" "${cookie_file}"
-        break
-      fi
-
-      local error_snippet=""
-      if [[ -s "${body_file}" ]]; then
-        error_snippet=$(head -c 200 "${body_file}" | tr -d '\r')
-      elif [[ -s "${headers_file}" ]]; then
-        error_snippet=$(head -c 200 "${headers_file}" | tr -d '\r')
-      fi
-
-      if [[ -n "${error_snippet}" ]]; then
-        log "${label} probe against ${url} returned HTTP ${http_code}; snippet: ${error_snippet}"
-      else
-        log "${label} probe against ${url} returned HTTP ${http_code}; will retry if attempts remain."
-      fi
-    else
-      curl_status=$?
-      local error_snippet=""
-      if [[ -s "${body_file}" ]]; then
-        error_snippet=$(head -c 200 "${body_file}" | tr -d '\r')
-      elif [[ -s "${headers_file}" ]]; then
-        error_snippet=$(head -c 200 "${headers_file}" | tr -d '\r')
-      fi
-      if [[ -n "${error_snippet}" ]]; then
-        log "${label} probe against ${url} failed (curl exit ${curl_status}). Snippet: ${error_snippet}"
-      else
-        log "${label} probe against ${url} failed (curl exit ${curl_status})."
-      fi
-    fi
-
-    rm -f "${headers_file}" "${body_file}" "${cookie_file}"
-  done
-
-  return "${status}"
-}
-
-smoke_test() {
-  local attempts=6
-  local sleep_seconds=20
-  local i
-  local prefix
-  local keycloak_path
-  local mp_path
-
-  local -a keycloak_urls=("http://${KC_HOST}")
-  local -a keycloak_paths=(
-    "/realms/rws/.well-known/openid-configuration"
-    "/realms/rws"
-    "/realms/master/.well-known/openid-configuration"
-    "/realms/master"
-  )
-
-  # Probe the default root context first; fall back to the legacy /auth base
-  # path if an older deployment still uses it.
-  for prefix in "" "/auth"; do
-    for keycloak_path in "${keycloak_paths[@]}"; do
-      keycloak_urls+=("http://${KC_HOST}${prefix}${keycloak_path}")
-    done
-  done
-
-  local -a midpoint_urls=()
-  for mp_path in "/midpoint/" "/midpoint" ""; do
-    midpoint_urls+=("http://${MP_HOST}${mp_path}")
-  done
-
-  for i in $(seq 1 "${attempts}"); do
-    log "HTTP availability check ${i}/${attempts}..."
-    if check_endpoint "Keycloak" "${keycloak_urls[@]}" && \
-       check_endpoint "midPoint" "${midpoint_urls[@]}"; then
-      log "Endpoints responded successfully."
-      return 0
-    fi
-
-    if [[ "${i}" -eq "${attempts}" ]]; then
-      log "ERROR: Keycloak or midPoint endpoint did not become reachable." >&2
-      kubectl -n ingress-nginx get svc ingress-nginx-controller -o wide || true
-      kubectl -n ingress-nginx get pods -l app.kubernetes.io/component=controller -o wide || true
-      kubectl -n "${NAMESPACE}" get ingress -o wide || true
-      exit 1
-    fi
-
-    log "Endpoints not ready yet; sleeping ${sleep_seconds}s before retry..."
-    sleep "${sleep_seconds}"
-  done
-}
 
 main() {
   wait_for_ingress_controller
   detect_ingress_class
   resolve_ingress_ip
   update_gitops_manifests
-  wait_for_keycloak
-  wait_for_midpoint
-  apply_ingresses
-  smoke_test
 
-  log "✅ Configuration complete."
-  log "Keycloak URL: http://${KC_HOST}/"
-  log "midPoint URL: http://${MP_HOST}/midpoint"
+  log "✅ Generated GitOps patches for ingress hosts."
+  log "Commit and push ${KEYCLOAK_HOST_PATCH_FILE} and ${MIDPOINT_INGRESS_PATCH_FILE} so Argo CD reconciles the new hostnames."
+  log "Keycloak host: http://${KC_HOST}/"
+  log "midPoint host: http://${MP_HOST}/midpoint"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- drop the imperative kubectl apply/patch logic from `configure_demo_hosts.sh`
- keep the helper focused on updating the GitOps patch files and logging next steps
- refresh the README to describe the GitOps-native flow

## Testing
- bash -n scripts/configure_demo_hosts.sh

------
https://chatgpt.com/codex/tasks/task_e_68d129154e28832bb1dd7e748a43af82