### PR TITLE
Remove redundant midPoint bootstrap artifacts

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1112,10 +1112,6 @@ jobs:
           kubectl -n ${{ inputs.NAMESPACE_IAM }} create secret generic midpoint-admin \
             --from-literal=password="$MIDPOINT_ADMIN_PASSWORD" \
             --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n ${{ inputs.NAMESPACE_IAM }} create configmap midpoint-config \
-            --from-file=config.xml=k8s/apps/midpoint/config.xml \
-            --dry-run=client -o yaml | kubectl apply -f -
-
       - name: Wait for Keycloak operator CRDs
         shell: bash
         run: |

--- a/k8s/apps/midpoint/kustomization.yaml
+++ b/k8s/apps/midpoint/kustomization.yaml
@@ -4,7 +4,6 @@ namespace: iam
 
 resources:
   - deployment.yaml
-  - precreate.yaml
   - ingress.yaml
   - seeder-job.yaml
 

--- a/k8s/apps/midpoint/precreate.yaml
+++ b/k8s/apps/midpoint/precreate.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: midpoint-admin
-  namespace: iam
-type: Opaque
-stringData:
-  password: "{{MIDPOINT_ADMIN_PASSWORD}}"


### PR DESCRIPTION
## Summary
- remove the placeholder midpoint-admin Secret from the GitOps kustomization so Argo CD stops reconciling fake credentials
- rely on the existing kustomize generator for midpoint-config and drop the imperative kubectl apply in the bootstrap workflow

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d129154e28832bb1dd7e748a43af82