### PR TITLE
Fix Argo CD bootstrap to target argocd namespace

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo "Applying vendored Argo CD install manifest (v3.1.6)"
-          kubectl apply -f k8s/argocd/install/argocd-install-v3.1.6.yaml
+          echo "Applying vendored Argo CD install manifest (v3.1.6) into namespace argocd"
+          kubectl apply -n argocd -f k8s/argocd/install/argocd-install-v3.1.6.yaml
           echo "Waiting for Argo CD core components to become ready..."
           for workload in deploy/argocd-server deploy/argocd-repo-server deploy/argocd-redis deploy/argocd-dex-server; do
             echo "Waiting for rollout of ${workload}"


### PR DESCRIPTION
## Summary
- ensure the Argo CD install manifest in the bootstrap workflow is applied to the argocd namespace so deployments appear where rollout checks expect them
- update the accompanying log message to mention the namespace being targeted

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d137484574832ba415ac8f3418a4db