### PR TITLE
Allow CNPG chart to install CRDs

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -37,10 +37,6 @@ spec:
                 targetRevision: 0.22.1
                 helm:
                   releaseName: cnpg
-                  skipCrds: true
-                  parameters:
-                    - name: crds.create
-                      value: "false"
               syncPolicy:
                 syncOptions:
                   - CreateNamespace=true


### PR DESCRIPTION
## Summary
- allow the CloudNativePG addon Helm release to manage its CRDs instead of skipping them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d14b12ee64832b86d37c4ba814060e