### PR TITLE
Fix ingress-nginx health probe path

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -53,15 +53,11 @@ spec:
                   releaseName: ingress-nginx
                   valuesObject:
                     controller:
-                      config:
-                        server-snippet: |
-                          location = /healthz {
-                            access_log off;
-                            return 200;
-                          }
                       service:
                         annotations:
-                          service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+                          service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /is-dynamic-lb-initialized
+                          # Use the built-in status endpoint exposed on the default server so Azure probes
+                          # get HTTP 200s even before any ingress rules exist.
                         type: LoadBalancer
               syncPolicy:
                 syncOptions:


### PR DESCRIPTION
## Summary
- point the ingress-nginx Azure load balancer probe at the controller's built-in status endpoint so probes pass before any user ingresses exist
- drop the custom server snippet that attempted to expose /healthz externally and document why the new probe path works

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d14e9b5508832b922c7ba21da712ee