### PR TITLE
Fix ApplicationSet template name interpolation

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -68,7 +68,7 @@ spec:
                   - CreateNamespace=true
   template:
     metadata:
-      name: '{{name}}'
+      name: '{{.name}}'
       namespace: argocd
     spec:
       project: default


### PR DESCRIPTION
## Summary
- fix the addons ApplicationSet template to use the correct go-template field for the generated Application name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d150a9c150832b87bd8f9a5285f549