### PR TITLE
Fix ApplicationSet go template name

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -64,7 +64,7 @@ spec:
                   - CreateNamespace=true
   template:
     metadata:
-      name: '{{name}}'
+      name: '{{.name}}'
       namespace: argocd
     spec:
       project: default


### PR DESCRIPTION
## Summary
- fix the addons ApplicationSet template to use the correct Go template placeholder for application names so rendering succeeds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d15598fb6c832bb7470820ca1a5848