### PR TITLE
Fix cnpg operator ApplicationSet source config

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -5,63 +5,34 @@ metadata:
   namespace: argocd
 spec:
   goTemplate: true
-  strategy:
-    type: merge
   generators:
     - list:
         elements:
           - name: cert-manager
-            spec:
-              destination:
-                namespace: cert-manager
-              source:
-                repoURL: https://charts.jetstack.io
-                chart: cert-manager
-                targetRevision: v1.15.1
-                helm:
-                  releaseName: cert-manager
-                  valuesObject:
-                    installCRDs: true
-                    prometheus:
-                      enabled: false
-              syncPolicy:
-                syncOptions:
-                  - CreateNamespace=true
+            namespace: cert-manager
+            repoURL: https://charts.jetstack.io
+            chart: cert-manager
+            targetRevision: v1.15.1
+            helmReleaseName: cert-manager
+            syncOptions:
+              - CreateNamespace=true
           - name: cnpg-operator
-            spec:
-              destination:
-                namespace: cnpg-system
-              source:
-                repoURL: https://cloudnative-pg.github.io/charts
-                chart: cloudnative-pg
-                targetRevision: 0.22.1
-                helm:
-                  releaseName: cnpg
-              syncPolicy:
-                syncOptions:
-                  - CreateNamespace=true
-                  - ServerSideApply=true
+            namespace: cnpg-system
+            repoURL: https://cloudnative-pg.github.io/charts
+            chart: cloudnative-pg
+            targetRevision: 0.22.1
+            helmReleaseName: cnpg
+            syncOptions:
+              - CreateNamespace=true
+              - ServerSideApply=true
           - name: ingress-nginx
-            spec:
-              destination:
-                namespace: ingress-nginx
-              source:
-                repoURL: https://kubernetes.github.io/ingress-nginx
-                chart: ingress-nginx
-                targetRevision: 4.10.1
-                helm:
-                  releaseName: ingress-nginx
-                  valuesObject:
-                    controller:
-                      service:
-                        annotations:
-                          service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /is-dynamic-lb-initialized
-                          # Use the built-in status endpoint exposed on the default server so Azure probes
-                          # get HTTP 200s even before any ingress rules exist.
-                        type: LoadBalancer
-              syncPolicy:
-                syncOptions:
-                  - CreateNamespace=true
+            namespace: ingress-nginx
+            repoURL: https://kubernetes.github.io/ingress-nginx
+            chart: ingress-nginx
+            targetRevision: 4.10.1
+            helmReleaseName: ingress-nginx
+            syncOptions:
+              - CreateNamespace=true
   template:
     metadata:
       name: '{{.name}}'
@@ -70,7 +41,35 @@ spec:
       project: default
       destination:
         server: https://kubernetes.default.svc
+        namespace: '{{.namespace}}'
+      source:
+        repoURL: '{{.repoURL}}'
+        chart: '{{.chart}}'
+        targetRevision: '{{.targetRevision}}'
+        helm:
+          releaseName: '{{.helmReleaseName}}'
+{{- if eq .name "cert-manager" }}
+          valuesObject:
+            installCRDs: true
+            prometheus:
+              enabled: false
+{{- else if eq .name "ingress-nginx" }}
+          valuesObject:
+            controller:
+              service:
+                annotations:
+                  # Use the built-in status endpoint exposed on the default server so Azure probes
+                  # get HTTP 200s even before any ingress rules exist.
+                  service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /is-dynamic-lb-initialized
+                type: LoadBalancer
+{{- end }}
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
+{{- if .syncOptions }}
+        syncOptions:
+{{- range .syncOptions }}
+          - {{ . }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- restructure the addons ApplicationSet generator entries to expose repo URL, chart, target revision, Helm release name, and sync options as explicit fields
- render the template spec fields from those explicit values so every generated Application includes a valid source definition, while still applying per-app Helm values where needed

## Testing
- (failed) yamllint k8s/addons/applicationset.yaml

------
https://chatgpt.com/codex/tasks/task_e_68d16035ea0c832bbf145c98947e8d43