### PR TITLE
Fix ApplicationSet templating whitespace in addons

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -24,7 +24,7 @@ spec:
         server: https://kubernetes.default.svc
         namespace: '{{.namespace}}'
       source:
-{{- if eq .name "cert-manager" }}
+      {{ if eq .name "cert-manager" }}
         repoURL: https://charts.jetstack.io
         chart: cert-manager
         targetRevision: v1.15.1
@@ -34,13 +34,13 @@ spec:
             installCRDs: true
             prometheus:
               enabled: false
-{{- else if eq .name "cnpg-operator" }}
+      {{ else if eq .name "cnpg-operator" }}
         repoURL: https://cloudnative-pg.github.io/charts
         chart: cloudnative-pg
         targetRevision: 0.22.1
         helm:
           releaseName: cnpg
-{{- else if eq .name "ingress-nginx" }}
+      {{ else if eq .name "ingress-nginx" }}
         repoURL: https://kubernetes.github.io/ingress-nginx
         chart: ingress-nginx
         targetRevision: 4.10.1
@@ -54,15 +54,15 @@ spec:
                   # get HTTP 200s even before any ingress rules exist.
                   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /is-dynamic-lb-initialized
                 type: LoadBalancer
-{{- end }}
+      {{ end }}
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
         syncOptions:
-{{- if eq .name "cnpg-operator" }}
+      {{ if eq .name "cnpg-operator" }}
           - CreateNamespace=true
           - ServerSideApply=true
-{{- else }}
+      {{ else }}
           - CreateNamespace=true
-{{- end }}
+      {{ end }}


### PR DESCRIPTION
## Summary
- stop trimming the newline after `source` and `syncOptions` so the generated ApplicationSet YAML stays well-formed
- indent the Go template directives to match the surrounding manifest structure for readability

## Testing
- ⚠️ `kustomize build k8s/addons >/tmp/addons.yaml` *(command unavailable in container)*
- ⚠️ `kubectl kustomize k8s/addons >/tmp/addons.yaml` *(command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16c492610832b80baf6a68762dd4d