### PR TITLE
Fix ingress class substitution in Kustomize

### DIFF
--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -15,6 +15,9 @@ configMapGenerator:
     envs:
       - params.env
 
+configurations:
+  - kustomizeconfig/ingress-vars.yaml
+
 vars:
   - name: INGRESS_CLASS
     objref:

--- a/k8s/apps/kustomizeconfig/ingress-vars.yaml
+++ b/k8s/apps/kustomizeconfig/ingress-vars.yaml
@@ -1,0 +1,7 @@
+varReference:
+  - path: spec/ingressClassName
+    kind: Ingress
+  - path: spec/rules[]/host
+    kind: Ingress
+  - path: spec/hostname
+    kind: Keycloak


### PR DESCRIPTION
## Summary
- add a kustomize configuration that maps ingress and keycloak fields for variable substitution
- register the configuration file in the apps kustomization so rendered manifests include the ingress class value

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d176588d00832b8335500dad70baa6