### PR TITLE
Use kustomize replacements for ingress hosts

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -49,7 +49,9 @@ spec:
   http:
     httpEnabled: true
   hostname:
-    hostname: $(KEYCLOAK_HOST)
+    # Default hostname is overridden by kustomize replacements using values
+    # from k8s/apps/params.env during the build.
+    hostname: kc.127.0.0.1.nip.io
     strict: false
   ingress:
     enabled: true

--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -15,28 +15,34 @@ configMapGenerator:
     envs:
       - params.env
 
-configurations:
-  - kustomizeconfig/ingress-vars.yaml
-
-vars:
-  - name: INGRESS_CLASS
-    objref:
-      apiVersion: v1
+replacements:
+  - source:
       kind: ConfigMap
       name: iam-ingress-settings
-    fieldref:
-      fieldpath: data.ingressClass
-  - name: KEYCLOAK_HOST
-    objref:
-      apiVersion: v1
+      fieldPath: data.ingressClass
+    targets:
+      - select:
+          kind: Ingress
+          name: midpoint
+        fieldPaths:
+          - spec.ingressClassName
+  - source:
       kind: ConfigMap
       name: iam-ingress-settings
-    fieldref:
-      fieldpath: data.keycloakHost
-  - name: MIDPOINT_HOST
-    objref:
-      apiVersion: v1
+      fieldPath: data.keycloakHost
+    targets:
+      - select:
+          kind: Keycloak
+          name: rws-keycloak
+        fieldPaths:
+          - spec.hostname.hostname
+  - source:
       kind: ConfigMap
       name: iam-ingress-settings
-    fieldref:
-      fieldpath: data.midpointHost
+      fieldPath: data.midpointHost
+    targets:
+      - select:
+          kind: Ingress
+          name: midpoint
+        fieldPaths:
+          - spec.rules.0.host

--- a/k8s/apps/kustomizeconfig/ingress-vars.yaml
+++ b/k8s/apps/kustomizeconfig/ingress-vars.yaml
@@ -1,7 +1,0 @@
-varReference:
-  - path: spec/ingressClassName
-    kind: Ingress
-  - path: spec/rules[]/host
-    kind: Ingress
-  - path: spec/hostname
-    kind: Keycloak

--- a/k8s/apps/midpoint/ingress.yaml
+++ b/k8s/apps/midpoint/ingress.yaml
@@ -6,9 +6,11 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "16m"
 spec:
-  ingressClassName: $(INGRESS_CLASS)
+  # Default ingress class/host values are overridden by kustomize replacements
+  # at build time using the values from k8s/apps/params.env.
+  ingressClassName: nginx
   rules:
-    - host: $(MIDPOINT_HOST)
+    - host: mp.127.0.0.1.nip.io
       http:
         paths:
           - path: /


### PR DESCRIPTION
## Summary
- replace the deprecated var substitution with kustomize replacements for the Keycloak and MidPoint ingress host settings
- keep stable default host/class values in the manifests so the rendered resources stay valid even before replacement
- drop the now-unused ingress var transformer configuration file

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/kustomize build k8s/apps

------
https://chatgpt.com/codex/tasks/task_e_68d179cd5e90832b872488ef4beecfb4