### PR TITLE
Fix argocd CLI usage in bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1360,14 +1360,14 @@ jobs:
           fi
 
           echo "Waiting for Argo CD application 'apps' to become Synced and Healthy"
-          if ! argocd app wait apps --sync --health --timeout 900 --core; then
+          if ! argocd --core app wait apps --sync --health --timeout 900; then
             echo "Argo CD application 'apps' failed to report Synced/Healthy within the timeout; dumping diagnostics."
             kubectl -n argocd get application apps -o yaml || true
             kubectl -n argocd get applications || true
             exit 1
           fi
 
-          argocd app get apps --core
+          argocd --core app get apps
 
       - name: Wait for Keycloak service endpoints
         shell: bash


### PR DESCRIPTION
## Summary
- call the Argo CD CLI in core mode using the correct flag placement when waiting on the apps application
- adjust the follow-up argocd app get invocation to match the corrected syntax

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d17e8dfbac832bb720b23c998d2daa