### PR TITLE
Fix demo host script regression

### DIFF
--- a/.github/workflows/04_configure_demo_hosts.yml
+++ b/.github/workflows/04_configure_demo_hosts.yml
@@ -58,19 +58,19 @@ jobs:
           set -euo pipefail
           bash scripts/configure_demo_hosts.sh
 
-      - name: Commit ingress host patches
+      - name: Commit ingress host parameters
         shell: bash
         run: |
           set -euo pipefail
           KC_HOST_VALUE="${KC_HOST:-}"
           MP_HOST_VALUE="${MP_HOST:-}"
           BRANCH_REF="${GITHUB_REF:-}"
-          if git diff --quiet --exit-code -- k8s/apps/keycloak/ingress-host-patch.yaml k8s/apps/midpoint/ingress-host-patch.yaml; then
-            echo "Ingress host patches already up to date; skipping commit."
+          if git diff --quiet --exit-code -- k8s/apps/params.env; then
+            echo "Ingress host parameters already up to date; skipping commit."
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add k8s/apps/keycloak/ingress-host-patch.yaml k8s/apps/midpoint/ingress-host-patch.yaml
+            git add k8s/apps/params.env
             git commit -m "Update demo ingress hosts to ${KC_HOST_VALUE} and ${MP_HOST_VALUE}"
             if [[ "${BRANCH_REF}" == refs/heads/* ]]; then
               BRANCH_NAME="${BRANCH_REF#refs/heads/}"

--- a/README.md
+++ b/README.md
@@ -104,10 +104,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 1. Run workflow **`04_configure_demo_hosts.yml`**.
 
 2. The helper script (`scripts/configure_demo_hosts.sh`) discovers the `ingress-nginx` load balancer address,
-   records the detected ingress class, and rewrites the GitOps host patches
-   (`k8s/apps/keycloak/hostname-patch.yaml` and `k8s/apps/midpoint/ingress-host-patch.yaml`) with
-   `kc.<IP>.nip.io` and `mp.<IP>.nip.io`. Commit those files after the workflow completes so Argo CD reconciles
-   the new hostnames straight from Git instead of relying on imperative `kubectl apply` calls.
+   records the detected ingress class, and rewrites the GitOps parameters file
+   (`k8s/apps/params.env`) with `kc.<IP>.nip.io` and `mp.<IP>.nip.io`. Commit that file after the workflow completes
+   so Argo CD reconciles the new hostnames straight from Git instead of relying on imperative `kubectl apply` calls.
 
 
 ## 5) Demo – what to click

--- a/scripts/configure_demo_hosts.sh
+++ b/scripts/configure_demo_hosts.sh
@@ -90,6 +90,9 @@ update_gitops_manifests() {
     exit 1
   fi
 
+  write_ingress_params "${PARAMS_ENV_FILE}" "${INGRESS_CLASS_NAME}" "${KC_HOST}" "${MP_HOST}"
+}
+
 resolve_ingress_ip() {
   local attempt max_attempts sleep_seconds
   local ip=""


### PR DESCRIPTION
## Summary
- restore the configure_demo_hosts.sh GitOps update logic so the script writes ingress parameters correctly
- update the configure_demo_hosts workflow to commit k8s/apps/params.env instead of the removed ingress patch files
- document the new params.env flow for publishing demo hosts

## Testing
- bash -n scripts/configure_demo_hosts.sh

------
https://chatgpt.com/codex/tasks/task_e_68d24935bbf4832bb959e24af92b2ead