### PR TITLE
Enable server-side apply for cert-manager and apps

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -54,7 +54,7 @@ spec:
         syncOptions:
           - CreateNamespace=true
   templatePatch: |
-    {{- if eq .name "cnpg-operator" }}
+    {{- if or (eq .name "cnpg-operator") (eq .name "cert-manager") }}
     spec:
       syncPolicy:
         syncOptions:

--- a/k8s/argocd/apps.yaml
+++ b/k8s/argocd/apps.yaml
@@ -25,3 +25,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary
- opt cert-manager into server-side apply in the addons ApplicationSet to prevent the webhook CA injection from causing perpetual drift
- enable server-side apply on the `apps` Argo CD application so operator-managed CRDs no longer fight with client-side apply updates

## Testing
- python3 - <<'PY'
import yaml, pathlib
for path in [
    pathlib.Path('k8s/addons/applicationset.yaml'),
    pathlib.Path('k8s/argocd/apps.yaml'),
]:
    with path.open() as f:
        yaml.safe_load(f)
    print(f"Loaded {path}")
PY

------
https://chatgpt.com/codex/tasks/task_e_68d25f669080832bab6c529048e9e243