### PR TITLE
Fix CNPG storage account substitution for backups

### DIFF
--- a/k8s/apps/cnpg/kustomization.yaml
+++ b/k8s/apps/cnpg/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster.yaml
+configurations:
+  - kustomizeconfig.yaml
 configMapGenerator:
   - name: cnpg-backup-settings
     namespace: iam

--- a/k8s/apps/cnpg/kustomizeconfig.yaml
+++ b/k8s/apps/cnpg/kustomizeconfig.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - path: spec/backup/barmanObjectStore/destinationPath
+    kind: Cluster


### PR DESCRIPTION
## Summary
- ensure the CloudNativePG cluster manifest receives the storage account from params.env when rendering the backup destination
- add a custom kustomize configuration so the generator-substituted value is applied during builds

## Testing
- kustomize build k8s/apps

------
https://chatgpt.com/codex/tasks/task_e_68d25f669080832bab6c529048e9e243