### PR TITLE
Fix CNPG cluster schema errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
      `k8s/apps/cnpg/params.env` with the Terraform `storage_account_name` before running this
      workflow so the rendered destination path matches the Azure Storage account that holds the
      backups.
-   - Configure CloudNativePG **managed roles and databases** so the `keycloak` and `midpoint` users, databases, and required extensions (`pgcrypto`, `pg_trgm`) stay in sync with the GitHub secrets on every reconcile.
+   - Configure CloudNativePG **managed roles** plus a post-init SQL script so the `keycloak` and `midpoint` users, databases, and required extensions (`pgcrypto`, `pg_trgm`) are provisioned from Git-managed secrets when the cluster bootstraps.
    - Install **Keycloak Operator** then create a **Keycloak** CR bound to CNPG
      - The workflow now reconfigures the operator deployment to watch the `iam` application namespace (in addition to its home namespace) so it publishes the generated services, such as `rws-keycloak-service`, where Argo CD manages the workloads.
    - Deploy **midPoint** bound to CNPG

--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -11,7 +11,6 @@ spec:
 
   superuserSecret:
     name: cnpg-superuser
-    namespace: iam
 
   bootstrap:
     initdb:
@@ -19,7 +18,10 @@ spec:
       owner: keycloak
       secret:
         name: keycloak-db-app
-        namespace: iam
+      postInitSQLRefs:
+        configMapRefs:
+          - name: cnpg-managed-databases
+            key: midpoint.sql
 
   managed:
     roles:
@@ -28,21 +30,11 @@ spec:
         passwordSecret:
           name: keycloak-db-app
           key: password
-          namespace: iam
       - name: midpoint
         login: true
         passwordSecret:
           name: midpoint-db-app
           key: password
-          namespace: iam
-    databases:
-      - name: keycloak
-        owner: keycloak
-      - name: midpoint
-        owner: midpoint
-        extensions:
-          - name: pgcrypto
-          - name: pg_trgm
 
   storage:
     size: 20Gi
@@ -58,11 +50,9 @@ spec:
         connectionString:
           name: cnpg-azure-backup
           key: AZURE_CONNECTION_STRING
-          namespace: iam
         storageAccount:
           name: cnpg-azure-backup
           key: AZURE_STORAGE_ACCOUNT
-          namespace: iam
       wal:
         compression: gzip
         maxParallel: 4

--- a/k8s/apps/cnpg/kustomization.yaml
+++ b/k8s/apps/cnpg/kustomization.yaml
@@ -9,6 +9,10 @@ configMapGenerator:
     namespace: iam
     envs:
       - params.env
+  - name: cnpg-managed-databases
+    namespace: iam
+    files:
+      - midpoint.sql
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/k8s/apps/cnpg/midpoint.sql
+++ b/k8s/apps/cnpg/midpoint.sql
@@ -1,0 +1,11 @@
+\set ON_ERROR_STOP on
+
+-- Create the midpoint database if it doesn't exist yet
+SELECT 'CREATE DATABASE midpoint OWNER midpoint TEMPLATE template1'
+WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint')\gexec
+
+\connect midpoint
+
+-- Ensure required extensions are present for midpoint
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;


### PR DESCRIPTION
## Summary
- drop unsupported namespace and managed database fields from the CNPG cluster and attach a post-init SQL hook instead
- generate a ConfigMap with SQL that provisions the midpoint database and extensions during bootstrap
- document the new bootstrap flow so operators know the database now comes from the SQL hook

## Testing
- kustomize build k8s/apps *(fails: `kustomize`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2658220bc832b8532ee0cb97e55f7