### PR TITLE
Align Keycloak ingress class with detected controller

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -60,6 +60,9 @@ spec:
     strict: false
   ingress:
     enabled: true
+    # Ingress class is overridden at build time by kustomize replacements using
+    # the detected value written to k8s/apps/params.env by
+    # scripts/configure_demo_hosts.sh.
     className: nginx
   resources:
     requests:

--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -22,6 +22,11 @@ replacements:
       fieldPath: data.ingressClass
     targets:
       - select:
+          kind: Keycloak
+          name: rws-keycloak
+        fieldPaths:
+          - spec.ingress.className
+      - select:
           kind: Ingress
           name: midpoint
         fieldPaths:


### PR DESCRIPTION
## Summary
- ensure the GitOps config rewrites the Keycloak ingress class using the detected ingress-nginx class name
- document in the Keycloak manifest that the class is overridden during the host configuration workflow

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d28389b19c832ba160916e9ba00f59