### PR TITLE
Fix CNPG managed role passwordSecret schema usage

### DIFF
--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -29,12 +29,10 @@ spec:
         login: true
         passwordSecret:
           name: keycloak-db-app
-          key: password
       - name: midpoint
         login: true
         passwordSecret:
           name: midpoint-db-app
-          key: password
 
   storage:
     size: 20Gi


### PR DESCRIPTION
## Summary
- remove the unsupported key field from managed role passwordSecret definitions so the CRD schema validates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d288c75160832bb69a3006e78f8cd4