### PR TITLE
Fix Keycloak ingress backend protocol for HTTP demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     `spec.additionalOptions` to guarantee the exact JDBC string (including the query parameters) always reaches the
     container even if the operator rewrites the database options. Without this override the startup probe repeatedly fails
     with `connection refused`, the pod restarts, and the application never reaches Healthy.
+  - The operator-managed Ingress defaults to routing traffic to Keycloak over HTTPS. The demo keeps the public endpoints on
+    plain HTTP for simplicity, so the manifest overrides the controller annotation to use an HTTP backend and disables the
+    automatic SSL redirect. Without this change ingress-nginx attempts an HTTPS handshake with Keycloak, never receives a
+    response, and the published `kc.<IP>.nip.io` URL times out even though the pods are healthy.
 
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
   - The deployment constrains the JVM heap (`MP_MEM_INIT=768M`, `MP_MEM_MAX=1536M`) to keep resource usage predictable.

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -64,6 +64,12 @@ spec:
     # the detected value written to k8s/apps/params.env by
     # scripts/configure_demo_hosts.sh.
     className: nginx
+    # Force the operator-managed ingress to proxy Keycloak over HTTP. The
+    # operator defaults to HTTPS backends, which breaks the demo's plain-HTTP
+    # routing through ingress-nginx.
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
   resources:
     requests:
       cpu: "250m"


### PR DESCRIPTION
## Summary
- force the Keycloak operator's generated ingress to speak HTTP to the service so the demo's plain-HTTP endpoints work again
- document the HTTP override in the README for future operators

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d285f86370832b85b6fd223626dfcf