### PR TITLE
Ensure midPoint database role exists during CloudNativePG bootstrap

### DIFF
--- a/k8s/apps/cnpg/midpoint.sql
+++ b/k8s/apps/cnpg/midpoint.sql
@@ -1,8 +1,44 @@
 \set ON_ERROR_STOP on
 
+-- Ensure the application role exists before we try to assign database ownership.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_roles
+    WHERE rolname = 'midpoint'
+  ) THEN
+    -- Password management is delegated to CloudNativePG managed roles;
+    -- we just need a login role to satisfy the owner constraint.
+    CREATE ROLE midpoint LOGIN;
+  ELSIF NOT EXISTS (
+    SELECT 1
+    FROM pg_roles
+    WHERE rolname = 'midpoint'
+      AND rolcanlogin
+  ) THEN
+    ALTER ROLE midpoint LOGIN;
+  END IF;
+END
+$$;
+
 -- Create the midpoint database if it doesn't exist yet
 SELECT 'CREATE DATABASE midpoint OWNER midpoint TEMPLATE template1'
 WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'midpoint')\gexec
+
+-- If the database already existed with a different owner (for example,
+-- during an earlier bootstrap attempt), reassign it to midpoint.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_database WHERE datname = 'midpoint'
+  ) AND EXISTS (
+    SELECT 1 FROM pg_roles WHERE rolname = 'midpoint'
+  ) THEN
+    EXECUTE 'ALTER DATABASE midpoint OWNER TO midpoint';
+  END IF;
+END
+$$;
 
 \connect midpoint
 


### PR DESCRIPTION
## Summary
- create the midpoint login role in the CloudNativePG post-init SQL if it does not exist yet
- reassign the midpoint database to that role to cover clusters created before the user was present

## Testing
- not run (SQL bootstrap change only)

------
https://chatgpt.com/codex/tasks/task_e_68d290d0da58832b8f30b7b49e8b2495