### PR TITLE
Use argocd CLI to wait for iam apps sync

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1403,25 +1403,24 @@ jobs:
             exit 1
           fi
 
-          echo "Waiting for Argo CD application 'apps' to become Synced and Healthy"
-          app_synced=0
-          for attempt in $(seq 1 9); do
-            sync_status=$(kubectl -n argocd get application apps -o jsonpath='{.status.sync.status}' 2>/dev/null || echo "")
-            health_status=$(kubectl -n argocd get application apps -o jsonpath='{.status.health.status}' 2>/dev/null || echo "")
-            revision_status=$(kubectl -n argocd get application apps -o jsonpath='{.status.sync.revision}' 2>/dev/null || echo "")
-
-            if [ "${sync_status}" = "Synced" ] && [ "${health_status}" = "Healthy" ]; then
-              echo "Argo CD application 'apps' is Synced and Healthy"
-              app_synced=1
-              break
+          if ! command -v argocd >/dev/null 2>&1; then
+            ARGOCD_VERSION="${ARGOCD_VERSION:-v3.1.6}"
+            CLI_URL="https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64"
+            echo "Installing Argo CD CLI ${ARGOCD_VERSION} from ${CLI_URL}"
+            cli_tmp="$(mktemp)"
+            if ! curl -fsSLo "${cli_tmp}" --connect-timeout 10 --max-time 120 --retry 5 --retry-delay 5 --retry-all-errors "${CLI_URL}"; then
+              echo "Failed to download Argo CD CLI from ${CLI_URL}" >&2
+              exit 1
             fi
+            install -m 0755 "${cli_tmp}" /usr/local/bin/argocd
+            rm -f "${cli_tmp}"
+            echo "Installed Argo CD CLI at /usr/local/bin/argocd"
+          fi
 
-            echo "Argo CD application 'apps' status: sync=${sync_status:-<unknown>} health=${health_status:-<unknown>} revision=${revision_status:-<unknown>} (attempt ${attempt}/9)"
-            sleep 10
-          done
-
-          if [ "${app_synced}" -ne 1 ]; then
-            echo "Argo CD application 'apps' failed to reach Synced/Healthy within the timeout; dumping diagnostics."
+          timeout_seconds=1200
+          echo "Waiting for Argo CD application 'apps' to reach Synced/Healthy (timeout ${timeout_seconds}s)"
+          if ! argocd app wait apps --core --sync --health --timeout "${timeout_seconds}"; then
+            echo "Argo CD application 'apps' failed to reach Synced/Healthy within ${timeout_seconds}s; dumping diagnostics."
             kubectl -n argocd get application apps -o yaml || true
             kubectl -n argocd get applications || true
             exit 1


### PR DESCRIPTION
## Summary
- install the Argo CD CLI in the bootstrap workflow when it is not already present
- replace the short polling loop with `argocd app wait --core --sync --health` and a longer timeout for the iam apps application

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d2a140bd74832ba8127d9828d75eb5