### PR TITLE
Fix Argo CD CLI core invocation in bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1419,7 +1419,7 @@ jobs:
 
           timeout_seconds=1200
           echo "Waiting for Argo CD application 'apps' to reach Synced/Healthy (timeout ${timeout_seconds}s)"
-          if ! argocd app wait apps --core --sync --health --timeout "${timeout_seconds}"; then
+          if ! argocd --core app wait apps --sync --health --timeout "${timeout_seconds}"; then
             echo "Argo CD application 'apps' failed to reach Synced/Healthy within ${timeout_seconds}s; dumping diagnostics."
             kubectl -n argocd get application apps -o yaml || true
             kubectl -n argocd get applications || true

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Deploy **midPoint** bound to CNPG
    - Create a Kubernetes **Secret** with Azure Blob credentials (from repo secrets) for CNPG backups
    - Purge any existing WAL/archive blobs in the Azure `cnpg-backups/iam-db` prefix so CloudNativePG can bootstrap cleanly on reruns
-   - The workflow now waits on the `apps` application by calling `argocd app wait --core --sync --health`, so you see Argo CD's native status output instead of bespoke polling. If reconciliation stalls, the CLI output highlights the objects Argo CD still considers out of sync.
+   - The workflow now waits on the `apps` application by calling `argocd --core app wait --sync --health`, so you see Argo CD's native status output instead of bespoke polling. If reconciliation stalls, the CLI output highlights the objects Argo CD still considers out of sync.
    - Argo CD ships with a custom health script for the Keycloak operator's CRDs (`Keycloak` and `KeycloakRealmImport`). The controller now marks those resources `Healthy` once the operator reports `status.ready=true`/`status.phase=Done`, so `argocd app wait --health` no longer stalls even though the pods respond to `/health/ready` on the management port.
 
 > By default, services are plain HTTP for simplicity and use **`nip.io`** hostnames you can visit from your browser.


### PR DESCRIPTION
## Summary
- invoke the Argo CD CLI with `--core` as a global flag when waiting on the apps application
- update the bootstrap README instructions to match the corrected CLI invocation

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2b61f3f28832b971116bc8dde8413