### PR TITLE
Use env vars for Keycloak health/metrics toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     differ...` when the optimized image still carries the default `kc.db=dev-file`/`kc.health-enabled=false` values from
     the upstream image, so letting the runtime build step execute avoids the crash loop without having to maintain a
     pre-built custom image.
-  - Keycloak enables the CLI flags `health-enabled=true` and `metrics-enabled=true` so the readiness endpoints expose the
+  - Keycloak sets `KC_HEALTH_ENABLED=true` and `KC_METRICS_ENABLED=true` so the readiness endpoints expose the
     `/health/ready` and database checks on the management port. The operator uses those endpoints for its probes and Argo CD's
     custom health script promotes the CRs to `Healthy` as soon as the operator reports `status.ready=true`.
     Keycloak 26.x removed the legacy `health` feature toggle, so the manifest pins `spec.features.enabled`

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -7,16 +7,17 @@ spec:
   image: quay.io/keycloak/keycloak:26.3.4
   instances: 1
   startOptimized: false
-  additionalOptions:
-    # Only keep CLI toggles that are still missing strongly typed equivalents in
-    # the v2alpha1 Keycloak CR. Strict HTTPS validation and the database URL now
-    # rely on the dedicated spec fields instead of legacy overrides.
-    # Enable Quarkus health/metrics endpoints so Kubernetes and the operator
-    # can call `/health/ready` during startup and surface Keycloak readiness to
-    # Argo CD's health checks.
-    - name: health-enabled
+  # Expose the Quarkus health and metrics endpoints through environment
+  # variables instead of the legacy CLI toggles. The operator translates
+  # `additionalOptions` into `--<option>` arguments and the Keycloak 26.x
+  # distribution now warns when first-class CR fields (such as `db-url` or
+  # `hostname-strict`) leak through that escape hatch. Using `KC_*` variables
+  # keeps the startup contract identical while avoiding the operator warning
+  # and the resulting CrashLoopBackOff.
+  env:
+    - name: KC_HEALTH_ENABLED
       value: "true"
-    - name: metrics-enabled
+    - name: KC_METRICS_ENABLED
       value: "true"
   # Pin the operator's feature list to a known good entry so it does not inject
   # the legacy "health" feature into KC_FEATURES. Keycloak 26 removed that flag


### PR DESCRIPTION
## Summary
- switch the Keycloak CR to set KC_HEALTH_ENABLED and KC_METRICS_ENABLED via `env` instead of CLI options so the operator stops injecting deprecated arguments that crash the pod
- document the new env-based configuration in the README for the demo operators

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2e804a75c832b8f5811873b6bda72