### PR TITLE
Fix CNPG post-init SQL for midpoint bootstrap

### DIFF
--- a/k8s/apps/cnpg/kustomization.yaml
+++ b/k8s/apps/cnpg/kustomization.yaml
@@ -10,6 +10,10 @@ configMapGenerator:
     namespace: iam
     envs:
       - params.env
+  - name: cnpg-managed-databases
+    namespace: iam
+    files:
+      - midpoint.sql
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/k8s/apps/cnpg/midpoint.sql
+++ b/k8s/apps/cnpg/midpoint.sql
@@ -1,0 +1,34 @@
+-- Ensure the midpoint application role exists and can log in.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_roles
+    WHERE rolname = 'midpoint'
+  ) THEN
+    CREATE ROLE midpoint LOGIN;
+  ELSIF NOT EXISTS (
+    SELECT 1
+    FROM pg_roles
+    WHERE rolname = 'midpoint'
+      AND rolcanlogin
+  ) THEN
+    ALTER ROLE midpoint LOGIN;
+  END IF;
+END
+$$;
+
+-- Create the midpoint database if it is missing, otherwise enforce the owner.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_database
+    WHERE datname = 'midpoint'
+  ) THEN
+    EXECUTE 'CREATE DATABASE midpoint OWNER midpoint TEMPLATE template1';
+  ELSE
+    EXECUTE 'ALTER DATABASE midpoint OWNER TO midpoint';
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- replace the midpoint post-init SQL with server-side DO blocks so CloudNativePG can execute it during init without relying on psql meta commands
- restore the configmap generator so the sanitized SQL ships with the cluster manifests

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d39cfa5fb4832b828957b588409cd8