### PR TITLE
Fix CNPG bootstrap SQL to avoid initdb failures

### DIFF
--- a/k8s/apps/cnpg/bootstrap-job.yaml
+++ b/k8s/apps/cnpg/bootstrap-job.yaml
@@ -65,6 +65,8 @@ spec:
                 --set=MIDPOINT_USER="${midpoint_username}" \
                 --set=MIDPOINT_PASSWORD="${midpoint_password}" \
                 --set=MIDPOINT_DB='midpoint' <<'SQL'
+\set ON_ERROR_STOP on
+
 DO $do$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'KEYCLOAK_USER') THEN
@@ -74,15 +76,15 @@ BEGIN
 END
 $do$;
 
-DO $do$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = :'KEYCLOAK_DB') THEN
-    EXECUTE format('CREATE DATABASE %I OWNER %I', :'KEYCLOAK_DB', :'KEYCLOAK_USER');
-  ELSE
-    EXECUTE format('ALTER DATABASE %I OWNER TO %I', :'KEYCLOAK_DB', :'KEYCLOAK_USER');
-  END IF;
-END
-$do$;
+SELECT format('CREATE DATABASE %I OWNER %I', :'KEYCLOAK_DB', :'KEYCLOAK_USER')
+WHERE NOT EXISTS (
+  SELECT 1 FROM pg_database WHERE datname = :'KEYCLOAK_DB'
+)\gexec
+
+SELECT format('ALTER DATABASE %I OWNER TO %I', :'KEYCLOAK_DB', :'KEYCLOAK_USER')
+WHERE EXISTS (
+  SELECT 1 FROM pg_database WHERE datname = :'KEYCLOAK_DB'
+)\gexec
 
 DO $do$
 BEGIN
@@ -93,20 +95,22 @@ BEGIN
 END
 $do$;
 
-DO $do$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = :'MIDPOINT_DB') THEN
-    EXECUTE format('CREATE DATABASE %I OWNER %I', :'MIDPOINT_DB', :'MIDPOINT_USER');
-  ELSE
-    EXECUTE format('ALTER DATABASE %I OWNER TO %I', :'MIDPOINT_DB', :'MIDPOINT_USER');
-  END IF;
-END
-$do$;
+SELECT format('CREATE DATABASE %I OWNER %I', :'MIDPOINT_DB', :'MIDPOINT_USER')
+WHERE NOT EXISTS (
+  SELECT 1 FROM pg_database WHERE datname = :'MIDPOINT_DB'
+)\gexec
+
+SELECT format('ALTER DATABASE %I OWNER TO %I', :'MIDPOINT_DB', :'MIDPOINT_USER')
+WHERE EXISTS (
+  SELECT 1 FROM pg_database WHERE datname = :'MIDPOINT_DB'
+)\gexec
 SQL
 
               "${psql_common[@]}" \
                 --dbname=midpoint \
                 --set=MIDPOINT_USER="${midpoint_username}" <<'SQL'
+\set ON_ERROR_STOP on
+
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 DO $do$

--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -9,6 +9,17 @@ spec:
   primaryUpdateStrategy: unsupervised
   enableSuperuserAccess: true
 
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      encoding: UTF8
+      localeCollate: C
+      localeCType: C
+      postInitSQLRefs: []
+      secret:
+        name: keycloak-db-app
+
   superuserSecret:
     name: cnpg-superuser
 
@@ -35,3 +46,20 @@ spec:
       data:
         compression: gzip
         jobs: 2
+
+  managed:
+    roles:
+      - name: keycloak
+        ensure: present
+        login: true
+        inherit: true
+        connectionLimit: -1
+        passwordSecret:
+          name: keycloak-db-app
+      - name: midpoint
+        ensure: present
+        login: true
+        inherit: true
+        connectionLimit: -1
+        passwordSecret:
+          name: midpoint-db-app


### PR DESCRIPTION
## Summary
- configure the CloudNativePG cluster to bootstrap the keycloak database without relying on post-init SQL scripts
- manage database roles through the operator and keep the bootstrap job responsible for idempotent database/user creation
- rewrite the bootstrap job SQL so database creation uses psql meta commands instead of DO blocks that fail during init

## Testing
- not run (YAML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d39cfa5fb4832b828957b588409cd8