### PR TITLE
Retain KC_HOSTNAME_STRICT_HTTPS via Keycloak CLI toggle

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -9,8 +9,8 @@ spec:
   startOptimized: false
   additionalOptions:
     # Only keep CLI toggles that are still missing strongly typed equivalents in
-    # the v2alpha1 Keycloak CR. Strict HTTPS validation and the database URL now
-    # rely on the dedicated spec fields instead of legacy overrides.
+    # the v2alpha1 Keycloak CR. Hostname strictness and the database URL now rely
+    # on the dedicated spec fields instead of the legacy CLI overrides.
     # Enable Quarkus health/metrics endpoints so Kubernetes and the operator
     # can call `/health/ready` during startup and surface Keycloak readiness to
     # Argo CD's health checks.
@@ -18,6 +18,11 @@ spec:
       value: "true"
     - name: metrics-enabled
       value: "true"
+    # Keycloak still lacks a typed knob for KC_HOSTNAME_STRICT_HTTPS, so retain
+    # the CLI switch to allow the demo ingress to terminate TLS in front of the
+    # pod while the runtime continues to serve plain HTTP.
+    - name: hostname-strict-https
+      value: "false"
   # Pin the operator's feature list to a known good entry so it does not inject
   # the legacy "health" feature into KC_FEATURES. Keycloak 26 removed that flag
   # and will crash if we request it, so we enable the health endpoints via


### PR DESCRIPTION
## Summary
- keep the Keycloak CLI override for `hostname-strict-https` since the CRD still lacks a typed field for that toggle
- clarify in the manifest comments that hostname strictness and the database URL are handled through the typed spec fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3d9e60454832ba6964c3b98c81a7a