### PR TITLE
Restore working Keycloak database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   `location`, `prefix`, `create_resource_group`, `resource_group_name`, `aks_default_node_vm_size`, `aks_default_node_count`, `aks_default_node_max_surge`, `aks_sku_tier` as needed.
 - **Helm/Argo versions**: see `k8s/addons/*/application.yaml`
 - **DB sizing**: `k8s/apps/cnpg/cluster.yaml`
-  - The demo cluster disables PostgreSQL TLS (`ssl=off`) so Keycloak can rely on
-    the CR's strongly typed database fields without reintroducing the deprecated
-    `--db-url` flag. If you secure the database with TLS, drop the override and
-    update the application manifests to mount the appropriate CA bundle.
 - **CNPG backup destination**: `k8s/apps/cnpg/params.env` – set `storageAccount` to the Terraform
   `storage_account_name` so Argo CD renders the correct backup URL. Keep it aligned with the
   `STORAGE_ACCOUNT` input when you trigger the bootstrap workflow.
@@ -177,11 +173,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
   - The Keycloak hostname section disables strict checks through `spec.hostname.strict=false` so the demo ingress can terminate
     HTTP without Keycloak rejecting the host/scheme. The nip.io address changes every time the AKS load balancer IP changes,
     so keeping the typed field relaxed avoids having to rely on the deprecated CLI toggles.
-  - The PostgreSQL connection now relies on the typed database fields (`spec.db.host`, `spec.db.port`, `spec.db.database`)
-    so the operator never renders the legacy `--db-url` CLI flag that Keycloak 26 rejects at startup. CloudNativePG accepts
-    plaintext connections from in-cluster clients by default, so the generated JDBC URL works without extra flags. If you
-    tighten the database's TLS policy, distribute the CA bundle and adjust the Keycloak database block accordingly so the
-    runtime configuration continues to match the new security posture.
+  - The PostgreSQL connection now uses an explicit JDBC URL with `sslmode=disable` so Keycloak skips TLS validation against
+    CloudNativePG's self-signed server certificate. The value lives in the CRD's database section via `spec.db.url` to guarantee
+    the exact JDBC string (including the query parameters) always reaches the container. Without this override the startup
+    probe repeatedly fails with `connection refused`, the pod restarts, and the application never reaches Healthy.
   - The operator-managed Ingress defaults to routing traffic to Keycloak over HTTPS. The demo keeps the public endpoints on
     plain HTTP for simplicity, so the manifest overrides the controller annotation to use an HTTP backend and disables the
     automatic SSL redirect. Without this change ingress-nginx attempts an HTTPS handshake with Keycloak, never receives a

--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -23,15 +23,6 @@ spec:
   superuserSecret:
     name: cnpg-superuser
 
-  postgresql:
-    parameters:
-      # Keycloak uses the typed database fields in its CR to avoid the legacy
-      # `--db-url` CLI override. Disable server-side TLS so the generated JDBC
-      # URL (which no longer appends `sslmode=disable`) still connects
-      # successfully without requiring a custom CA bundle. MidPoint continues to
-      # request plain TCP connections explicitly in its configuration file.
-      ssl: "off"
-
   storage:
     size: 20Gi
 

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -28,13 +28,11 @@ spec:
     enabled:
       - token-exchange
   db:
-    # Drive the database configuration through the strongly typed fields so the
-    # operator does not have to fall back to the deprecated CLI flags (Keycloak
-    # 26.x now fails hard when `--db-url` is provided).
+    # Inject the explicit JDBC string (including `sslmode=disable`) via the
+    # strongly typed field so the operator no longer requires the deprecated
+    # CLI override.
     vendor: postgres
-    host: iam-db-rw.iam.svc.cluster.local
-    port: 5432
-    database: keycloak
+    url: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=disable
     usernameSecret:
       name: keycloak-db-app
       key: username


### PR DESCRIPTION
## Summary
- restore the Keycloak manifest to use the explicit JDBC URL with `sslmode=disable`
- drop the CloudNativePG TLS override that was added to support typed DB fields
- align the README with the reverted database connection guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3d9e60454832ba6964c3b98c81a7a