### PR TITLE
Handle Keycloak crashloop by using typed DB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     so the operator never renders the legacy `--db-url` CLI flag that Keycloak 26 rejects at startup. CloudNativePG's cluster
     manifest disables server-side TLS for the demo, letting the generated JDBC URL work without extra flags. If you tighten
     the database's TLS policy, distribute the CA bundle and adjust the Keycloak database block accordingly so the runtime
-    configuration continues to match the new security posture.
+    configuration continues to match the new security posture. If you see Argo CD report `warning: You need to specify these
+    fields as the first-class citizen of the CR: features,hostname-strict,db-url`, double-check that no overrides reintroduced
+    those CLI switches—Keycloak will crash-loop with that configuration.
   - The operator-managed Ingress defaults to routing traffic to Keycloak over HTTPS. The demo keeps the public endpoints on
     plain HTTP for simplicity, so the manifest overrides the controller annotation to use an HTTP backend and disables the
     automatic SSL redirect. Without this change ingress-nginx attempts an HTTPS handshake with Keycloak, never receives a

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -43,6 +43,10 @@ spec:
     host: iam-db-rw.iam.svc.cluster.local
     port: 5432
     database: keycloak
+    # Keycloak defaults to the "public" schema when connecting to PostgreSQL.
+    # Declare it explicitly so future operator releases do not infer a schema
+    # switch that would force us back to the deprecated `--db-url` CLI flag.
+    schema: public
     usernameSecret:
       name: keycloak-db-app
       key: username


### PR DESCRIPTION
## Summary
- explicitly set the Keycloak database schema to `public` so the operator does not fall back to the deprecated `--db-url` flag
- document the Argo CD warning emitted when legacy CLI toggles are reintroduced and explain the crashloop side effect

## Testing
- not run (configuration/documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d3ee14e068832baabb689858603471