### PR TITLE
Ensure Keycloak uses typed fields for critical options

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     Setting `spec.features.disabled` to `health` still makes the operator render the removed toggle, so the disabled list stays
     empty. If you upgrade the image again and the health endpoints disappear, review the upstream release notes for the
     replacement configuration knob before adjusting the feature list.
+  - Keep the **first-class configuration** inside the strongly typed sections of the CR instead of `spec.additionalOptions`.
+    Run `scripts/check_keycloak_first_class_fields.py` after editing the manifest; it fails fast when someone reintroduces the
+    deprecated `--db-url`, `--hostname-strict` or `--features` flags or revives `spec.db.url`, which caused the CrashLoopBackOff
+    observed in the bootstrap logs.
 
   - The manifest pins Keycloak to **26.3.4** to stay aligned with the operator resources the workflow installs.
     Keycloak 26.0.0 fails to start once build-time options such as `kc.db` or `kc.health-enabled` diverge from the

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -60,6 +60,10 @@ spec:
     # IP changes, so keep hostname checks disabled via the typed spec field
     # instead of the deprecated CLI toggle.
     strict: false
+    # Relax backchannel hostname verification with the strongly typed knob so
+    # we do not have to fall back to the legacy `--hostname-strict` CLI flag
+    # that Keycloak 26 rejects.
+    strictBackchannel: false
   ingress:
     enabled: true
     # Ingress class is overridden at build time by kustomize replacements using

--- a/scripts/check_keycloak_first_class_fields.py
+++ b/scripts/check_keycloak_first_class_fields.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Validate that the Keycloak CR only uses strongly typed fields for first-class options."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = REPO_ROOT / "k8s/apps/keycloak/keycloak.yaml"
+
+BANNED_ADDITIONAL_OPTIONS = {
+    re.compile(r"^\s*-?\s*name:\s*db-url\s*$", re.MULTILINE): "--db-url",
+    re.compile(r"^\s*-?\s*name:\s*hostname-strict\s*$", re.MULTILINE): "--hostname-strict",
+    re.compile(r"^\s*-?\s*name:\s*features\s*$", re.MULTILINE): "--features",
+}
+
+
+def main() -> int:
+    text = MANIFEST.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    for pattern, flag in BANNED_ADDITIONAL_OPTIONS.items():
+        if pattern.search(text):
+            errors.append(
+                "Keycloak manifest must not configure "
+                f"{flag} via additionalOptions (pattern '{pattern.pattern}')."
+            )
+
+    db_block_match = re.search(r"^  db:\n(?P<body>(?:^(?: {4}|\t).*(?:\n|$))*)", text, re.MULTILINE)
+    if db_block_match:
+        body = db_block_match.group("body")
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("url:"):
+                errors.append(
+                    "Keycloak manifest must drive the database connection through typed host/port/database fields instead of spec.db.url."
+                )
+                break
+    else:
+        errors.append("Unable to locate spec.db block in Keycloak manifest; update the checker if the manifest moved.")
+
+    if errors:
+        for message in errors:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- relax Keycloak backchannel hostname checks through the typed CR field so we avoid legacy CLI toggles
- document the typed-field requirement and add a guard script that fails if deprecated CLI flags or spec.db.url reappear

## Testing
- `scripts/check_keycloak_first_class_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3ee14e068832baabb689858603471