### PR TITLE
Fix Argo CD applications to follow the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Create a Kubernetes **Secret** with Azure Blob credentials (from repo secrets) for CNPG backups
    - Purge any existing WAL/archive blobs in the Azure `cnpg-backups/iam-db` prefix so CloudNativePG can bootstrap cleanly on reruns
    - The workflow now waits on the `apps` application by calling `argocd --core app wait --sync --health`, so you see Argo CD's native status output instead of bespoke polling. If reconciliation stalls, the CLI output highlights the objects Argo CD still considers out of sync.
+   - Both Argo CD Applications now track the explicit **`main`** branch (instead of the symbolic `HEAD` ref) so the repo server refreshes to the latest commit as soon as you push. If you promote changes from another branch, update the manifests' `targetRevision` fields accordingly before running the workflow.
    - Argo CD ships with a custom health script for the Keycloak operator's CRDs (`Keycloak` and `KeycloakRealmImport`). The controller now marks those resources `Healthy` once the operator reports `status.ready=true`/`status.phase=Done`, so `argocd app wait --health` no longer stalls even though the pods respond to `/health/ready` on the management port.
 
 > By default, services are plain HTTP for simplicity and use **`nip.io`** hostnames you can visit from your browser.

--- a/k8s/argocd/apps.yaml
+++ b/k8s/argocd/apps.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: argocd
   source:
     repoURL: https://github.com/${REPO_OWNER}/${REPO_NAME}
-    targetRevision: HEAD
+    targetRevision: main
     path: k8s/apps
   ignoreDifferences:
     - group: k8s.keycloak.org

--- a/k8s/argocd/root-apps.yaml
+++ b/k8s/argocd/root-apps.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: argocd
   source:
     repoURL: https://github.com/${REPO_OWNER}/${REPO_NAME}
-    targetRevision: HEAD
+    targetRevision: main
     path: k8s/addons
   syncPolicy:
     automated:


### PR DESCRIPTION
## Summary
- point the `apps` and `addons` Argo CD Applications at the `main` branch instead of the symbolic `HEAD` ref so repo-server picks up fresh commits immediately
- document the branch-tracking requirement in the bootstrap README guidance so operators know to update `targetRevision` if they promote from another branch

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3fab6d77c832b98ab05223a0439e0