### PR TITLE
Fix indentation in CNPG bootstrap job heredocs

### DIFF
--- a/k8s/apps/cnpg/bootstrap-job.yaml
+++ b/k8s/apps/cnpg/bootstrap-job.yaml
@@ -65,60 +65,60 @@ spec:
                 --set=MIDPOINT_USER="${midpoint_username}" \
                 --set=MIDPOINT_PASSWORD="${midpoint_password}" \
                 --set=MIDPOINT_DB='midpoint' <<'SQL'
-\set ON_ERROR_STOP on
+                \set ON_ERROR_STOP on
 
-DO $do$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'KEYCLOAK_USER') THEN
-    EXECUTE format('CREATE ROLE %I LOGIN', :'KEYCLOAK_USER');
-  END IF;
-  EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'KEYCLOAK_USER', :'KEYCLOAK_PASSWORD');
-END
-$do$;
+                DO $do$
+                BEGIN
+                  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'KEYCLOAK_USER') THEN
+                    EXECUTE format('CREATE ROLE %I LOGIN', :'KEYCLOAK_USER');
+                  END IF;
+                  EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'KEYCLOAK_USER', :'KEYCLOAK_PASSWORD');
+                END
+                $do$;
 
-SELECT format('CREATE DATABASE %I OWNER %I', :'KEYCLOAK_DB', :'KEYCLOAK_USER')
-WHERE NOT EXISTS (
-  SELECT 1 FROM pg_database WHERE datname = :'KEYCLOAK_DB'
-)\gexec
+                SELECT format('CREATE DATABASE %I OWNER %I', :'KEYCLOAK_DB', :'KEYCLOAK_USER')
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM pg_database WHERE datname = :'KEYCLOAK_DB'
+                )\gexec
 
-SELECT format('ALTER DATABASE %I OWNER TO %I', :'KEYCLOAK_DB', :'KEYCLOAK_USER')
-WHERE EXISTS (
-  SELECT 1 FROM pg_database WHERE datname = :'KEYCLOAK_DB'
-)\gexec
+                SELECT format('ALTER DATABASE %I OWNER TO %I', :'KEYCLOAK_DB', :'KEYCLOAK_USER')
+                WHERE EXISTS (
+                  SELECT 1 FROM pg_database WHERE datname = :'KEYCLOAK_DB'
+                )\gexec
 
-DO $do$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'MIDPOINT_USER') THEN
-    EXECUTE format('CREATE ROLE %I LOGIN', :'MIDPOINT_USER');
-  END IF;
-  EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'MIDPOINT_USER', :'MIDPOINT_PASSWORD');
-END
-$do$;
+                DO $do$
+                BEGIN
+                  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'MIDPOINT_USER') THEN
+                    EXECUTE format('CREATE ROLE %I LOGIN', :'MIDPOINT_USER');
+                  END IF;
+                  EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'MIDPOINT_USER', :'MIDPOINT_PASSWORD');
+                END
+                $do$;
 
-SELECT format('CREATE DATABASE %I OWNER %I', :'MIDPOINT_DB', :'MIDPOINT_USER')
-WHERE NOT EXISTS (
-  SELECT 1 FROM pg_database WHERE datname = :'MIDPOINT_DB'
-)\gexec
+                SELECT format('CREATE DATABASE %I OWNER %I', :'MIDPOINT_DB', :'MIDPOINT_USER')
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM pg_database WHERE datname = :'MIDPOINT_DB'
+                )\gexec
 
-SELECT format('ALTER DATABASE %I OWNER TO %I', :'MIDPOINT_DB', :'MIDPOINT_USER')
-WHERE EXISTS (
-  SELECT 1 FROM pg_database WHERE datname = :'MIDPOINT_DB'
-)\gexec
-SQL
+                SELECT format('ALTER DATABASE %I OWNER TO %I', :'MIDPOINT_DB', :'MIDPOINT_USER')
+                WHERE EXISTS (
+                  SELECT 1 FROM pg_database WHERE datname = :'MIDPOINT_DB'
+                )\gexec
+                SQL
 
               "${psql_common[@]}" \
                 --dbname=midpoint \
                 --set=MIDPOINT_USER="${midpoint_username}" <<'SQL'
-\set ON_ERROR_STOP on
+                \set ON_ERROR_STOP on
 
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
-DO $do$
-BEGIN
-  EXECUTE format('GRANT ALL PRIVILEGES ON SCHEMA public TO %I', :'MIDPOINT_USER');
-END
-$do$;
-SQL
+                CREATE EXTENSION IF NOT EXISTS pgcrypto;
+                CREATE EXTENSION IF NOT EXISTS pg_trgm;
+                DO $do$
+                BEGIN
+                  EXECUTE format('GRANT ALL PRIVILEGES ON SCHEMA public TO %I', :'MIDPOINT_USER');
+                END
+                $do$;
+                SQL
           volumeMounts:
             - name: superuser-secret
               mountPath: /var/run/secrets/cnpg-superuser


### PR DESCRIPTION
## Summary
- indent the SQL heredoc bodies in the CNPG bootstrap job so they remain within the Bash script literal
- ensure the YAML parser no longer stops the multi-line string prematurely by keeping consistent indentation

## Testing
- kustomize build k8s/apps *(fails: `kustomize` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4164d2870832ba9715048b4204614