### PR TITLE
Fix CNPG initdb spec to avoid invalid postInitSQLRefs

### DIFF
--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -16,7 +16,6 @@ spec:
       encoding: UTF8
       localeCollate: C
       localeCType: C
-      postInitSQLRefs: []
       secret:
         name: keycloak-db-app
 


### PR DESCRIPTION
## Summary
- remove the empty postInitSQLRefs stanza from the CloudNativePG cluster manifest so it conforms to the CRD schema

## Testing
- not run (declarative manifest change only)


------
https://chatgpt.com/codex/tasks/task_e_68d41b55d468832b98f0e1e759fe81a8