### PR TITLE
fix: remove empty postInitSQLRefs from cnpg cluster

### DIFF
--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -16,7 +16,6 @@ spec:
       encoding: UTF8
       localeCollate: C
       localeCType: C
-      postInitSQLRefs: []
       secret:
         name: keycloak-db-app
 


### PR DESCRIPTION
## Summary
- remove the empty postInitSQLRefs array from the CNPG Cluster manifest so it matches the CRD schema and can be applied by Argo CD

## Testing
- kustomize build k8s/apps *(fails: kustomize is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4216c71fc832bbe8eb3dffa5da367