### PR TITLE
Ensure CNPG CRDs install with Argo

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -21,7 +21,7 @@ spec:
             chart: cloudnative-pg
             targetRevision: 0.22.1
             releaseName: cnpg
-            values: '{}'
+            values: '{"crds":{"create":true}}'
           - name: ingress-nginx
             namespace: ingress-nginx
             repoURL: https://kubernetes.github.io/ingress-nginx
@@ -89,6 +89,9 @@ spec:
           - ServerSideApply=true
     {{- else if eq .name "cnpg-operator" }}
     spec:
+      source:
+        helm:
+          skipCrds: false
       syncPolicy:
         syncOptions:
           - CreateNamespace=true


### PR DESCRIPTION
## Summary
- configure the cnpg-operator Application to explicitly render CRDs when templated by Argo CD
- disable Helm CRD skipping so the Database and Cluster CRDs are applied before app sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42d5d8f54832bb676919ea218b7b6