### PR TITLE
Upgrade CNPG chart to include Database CRD

### DIFF
--- a/k8s/addons/applicationset.yaml
+++ b/k8s/addons/applicationset.yaml
@@ -19,7 +19,7 @@ spec:
             namespace: cnpg-system
             repoURL: https://cloudnative-pg.github.io/charts
             chart: cloudnative-pg
-            targetRevision: 0.22.1
+            targetRevision: 0.24.0
             releaseName: cnpg
             values: '{}'
           - name: ingress-nginx


### PR DESCRIPTION
## Summary
- bump the CloudNativePG Helm chart so that the Database CRD is installed for Argo CD sync

## Testing
- not run (manifest-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d42d5d8f54832bb676919ea218b7b6