### PR TITLE
Align CNPG CRD preinstall with deployed chart

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -153,7 +153,7 @@ jobs:
           fi
 
           CNPG_CHART_NAME="cloudnative-pg"
-          CNPG_CHART_VERSION="0.22.1"
+          CNPG_CHART_VERSION="0.26.0"
           CNPG_CHART_REF="cloudnative-pg/${CNPG_CHART_NAME}"
 
           echo "Adding CloudNativePG Helm repository"


### PR DESCRIPTION
## Summary
- update the CloudNativePG chart version used during workflow CRD preinstallation to 0.26.0 so it matches the Argo CD deployment

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d43c4454b4832bb18136433cf8fbbf