### PR TITLE
Fix CNPG storage account variable reference

### DIFF
--- a/k8s/apps/cnpg/kustomization.yaml
+++ b/k8s/apps/cnpg/kustomization.yaml
@@ -19,4 +19,4 @@ vars:
       kind: ConfigMap
       name: cnpg-backup-settings
     fieldref:
-      fieldpath: data.storageAccount
+      fieldPath: data.storageAccount


### PR DESCRIPTION
## Summary
- fix the CloudNativePG kustomize variable configuration so the storage account value resolves correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d43fb6a688832ba595a330b3eceede