### PR TITLE
Add retry policy to apps Argo CD application

### DIFF
--- a/k8s/argocd/apps.yaml
+++ b/k8s/argocd/apps.yaml
@@ -23,6 +23,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 6
+      backoff:
+        duration: 30s
+        factor: 2
+        maxDuration: 5m
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true


### PR DESCRIPTION
## Summary
- configure the Argo CD `apps` Application with an automated retry policy
- allow failed syncs caused by missing CRDs to back off and retry until operators become ready

## Testing
- not run (declarative configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d43fb6a688832ba595a330b3eceede