### PR TITLE
Enable TLS defaults for CloudNativePG clients

### DIFF
--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -22,14 +22,6 @@ spec:
   superuserSecret:
     name: cnpg-superuser
 
-  postgresql:
-    parameters:
-      # Keycloak and midPoint both request plaintext connections via their
-      # strongly typed database settings. Disable server-side TLS so the
-      # generated JDBC URLs connect successfully without mounting a custom CA
-      # bundle into each workload.
-      ssl: "off"
-
   storage:
     size: 20Gi
 

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -35,10 +35,9 @@ spec:
   db:
     # Drive the database configuration through the strongly typed fields so the
     # operator does not have to fall back to the deprecated CLI flags (Keycloak
-    # 26.x fails hard when `--db-url` is provided). CloudNativePG accepts
-    # plaintext connections from in-cluster clients once TLS is disabled at the
-    # cluster level, so the generated JDBC URL works without additional query
-    # parameters.
+    # 26.x fails hard when `--db-url` is provided). CloudNativePG defaults to
+    # TLS and Keycloak negotiates it automatically, so the generated JDBC URL
+    # works without extra query parameters.
     vendor: postgres
     host: iam-db-rw.iam.svc.cluster.local
     port: 5432

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -478,7 +478,7 @@ spec:
                 name: midpoint-env
           env:
             - name: MIDPOINT_JDBC_URL
-              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=disable
+              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=require
             - name: MIDPOINT_DB_USERNAME_FILE
               value: /var/run/secrets/midpoint-db-app/username
             - name: MIDPOINT_DB_PASSWORD_FILE


### PR DESCRIPTION
## Summary
- remove the attempt to disable PostgreSQL SSL on the CloudNativePG cluster so the webhook admits the resource
- require TLS for the midPoint JDBC URL and document the new behavior for both workloads
- clarify that Keycloak negotiates the default TLS connection without extra parameters

## Testing
- `kustomize build k8s/apps` *(fails: command not found)*
- `kubectl kustomize k8s/apps` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d43fb6a688832ba595a330b3eceede