### PR TITLE
Update demo ingress hosts to new load balancer IP

### DIFF
--- a/k8s/apps/params.env
+++ b/k8s/apps/params.env
@@ -1,5 +1,5 @@
 # Ingress parameters for the IAM demo environment.
 # Updated by scripts/configure_demo_hosts.sh.
 ingressClass=nginx
-keycloakHost=kc.4.175.49.32.nip.io
-midpointHost=mp.4.175.49.32.nip.io
+keycloakHost=kc.132.220.156.13.nip.io
+midpointHost=mp.132.220.156.13.nip.io


### PR DESCRIPTION
## Summary
- update the GitOps-managed hostnames for Keycloak and midPoint to target the new 132.220.156.13 load balancer address

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d449fd01b4832bade4faa1e2c6712c