### PR TITLE
Fix Keycloak startup probe to use HTTP port

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -86,3 +86,15 @@ spec:
     limits:
       cpu: "1"
       memory: "2Gi"
+  # The operator defaults the startup probe to the management port (9000), but
+  # this demo only exposes the HTTP listener during bootstrap. Point the probe
+  # at the HTTP health endpoint and give Keycloak enough time to finish the
+  # first-run augmentation step before Kubernetes restarts the pod.
+  startupProbe:
+    httpGet:
+      path: /health/started
+      port: 8080
+      scheme: HTTP
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    failureThreshold: 12


### PR DESCRIPTION
## Summary
- point the Keycloak startup probe at the HTTP listener instead of the management port
- extend the probe timing so the initial augmentation completes before Kubernetes restarts the pod

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d44b69894c832b8ed5221397fbca2e