### PR TITLE
Disable CNPG WAL archive check for existing archives

### DIFF
--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -42,6 +42,8 @@ spec:
       wal:
         compression: gzip
         maxParallel: 4
+        archiveCheck:
+          enabled: false
       data:
         compression: gzip
         jobs: 2


### PR DESCRIPTION
## Summary
- disable the barman archive check so the CNPG cluster can reuse a non-empty Azure Blob path for WALs

## Testing
- kustomize build k8s/apps/cnpg *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d450c9f408832b84fca1850de6d8f8