### PR TITLE
Align Keycloak startup probe patch with older CRDs

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -89,12 +89,19 @@ spec:
   # The operator defaults the startup probe to the management port (9000), but
   # this demo only exposes the HTTP listener during bootstrap. Point the probe
   # at the HTTP health endpoint and give Keycloak enough time to finish the
-  # first-run augmentation step before Kubernetes restarts the pod.
-  startupProbe:
-    httpGet:
-      path: /health/started
-      port: 8080
-      scheme: HTTP
-    initialDelaySeconds: 30
-    periodSeconds: 5
-    failureThreshold: 12
+  # first-run augmentation step before Kubernetes restarts the pod. Older
+  # operator releases do not yet expose the strongly typed `spec.startupProbe`
+  # field, so patch the generated PodTemplate instead to stay compatible with
+  # both the legacy and the v2alpha1 CRDs.
+  podTemplate:
+    spec:
+      containers:
+        - name: keycloak
+          startupProbe:
+            httpGet:
+              path: /health/started
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            failureThreshold: 12


### PR DESCRIPTION
## Summary
- move the Keycloak startupProbe override into the pod template so it works across older CRD schemas
- keep the startup HTTP health check configuration intact while remaining compatible with v2alpha1 resources

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d45294eb40832b99b76008a93ef267