### PR TITLE
Use unsupported podTemplate for Keycloak startup probe

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -89,19 +89,21 @@ spec:
   # The operator defaults the startup probe to the management port (9000), but
   # this demo only exposes the HTTP listener during bootstrap. Point the probe
   # at the HTTP health endpoint and give Keycloak enough time to finish the
-  # first-run augmentation step before Kubernetes restarts the pod. Older
-  # operator releases do not yet expose the strongly typed `spec.startupProbe`
-  # field, so patch the generated PodTemplate instead to stay compatible with
-  # both the legacy and the v2alpha1 CRDs.
-  podTemplate:
-    spec:
-      containers:
-        - name: keycloak
-          startupProbe:
-            httpGet:
-              path: /health/started
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 30
-            periodSeconds: 5
-            failureThreshold: 12
+  # first-run augmentation step before Kubernetes restarts the pod. The
+  # v2alpha1 CRD now exposes the strongly typed `spec.startupProbe`, but it only
+  # allows tuning thresholds and still targets the management port. Use the
+  # `unsupported.podTemplate` escape hatch so we can continue to override the
+  # full probe configuration.
+  unsupported:
+    podTemplate:
+      spec:
+        containers:
+          - name: keycloak
+            startupProbe:
+              httpGet:
+                path: /health/started
+                port: 8080
+                scheme: HTTP
+              initialDelaySeconds: 30
+              periodSeconds: 5
+              failureThreshold: 12


### PR DESCRIPTION
## Summary
- move the Keycloak startup probe override under spec.unsupported.podTemplate so it matches the v2alpha1 CRD schema
- document why the unsupported escape hatch is required to keep probing the HTTP health endpoint

## Testing
- python3 scripts/check_keycloak_first_class_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68d4544ddeac832b99970bc250cb102c