### PR TITLE
Remove unsupported startupProbe flag from Keycloak spec

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -94,7 +94,6 @@ spec:
   # `/health/ready` handler available during bootstrap. Relax the thresholds so
   # Keycloak can finish the initial augmentation without the pod cycling.
   startupProbe:
-    enabled: true
     initialDelaySeconds: 30
     periodSeconds: 5
     failureThreshold: 12


### PR DESCRIPTION
## Summary
- remove the unsupported `spec.startupProbe.enabled` flag from the Keycloak CR so Argo CD can apply it server-side

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d45b1d1cec832bb3e796cbc09dcd62