### PR TITLE
Remove unsupported archiveCheck field from CNPG cluster manifest

### DIFF
--- a/k8s/apps/cnpg/cluster.yaml
+++ b/k8s/apps/cnpg/cluster.yaml
@@ -42,8 +42,6 @@ spec:
       wal:
         compression: gzip
         maxParallel: 4
-        archiveCheck:
-          enabled: false
       data:
         compression: gzip
         jobs: 2


### PR DESCRIPTION
## Summary
- remove the unsupported `archiveCheck` stanza from the CNPG backup configuration
- rely on schema-supported WAL settings to avoid Argo CD comparison errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d45e62133c832b9cceca3dab61f6b3