### PR TITLE
Remove unsupported initial delay from Keycloak startup probe

### DIFF
--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -91,9 +91,9 @@ spec:
   # the probe configuration inside the supported schema rather than the
   # `unsupported.podTemplate` escape hatch. The operator still defaults to the
   # management port, but enabling the Quarkus health endpoints above keeps the
-  # `/health/ready` handler available during bootstrap. Relax the thresholds so
-  # Keycloak can finish the initial augmentation without the pod cycling.
+  # `/health/ready` handler available during bootstrap. The CRD currently lacks
+  # an `initialDelaySeconds` knob, so we rely on a more permissive probe
+  # threshold to keep Keycloak alive while it performs the initial augmentation.
   startupProbe:
-    initialDelaySeconds: 30
     periodSeconds: 5
     failureThreshold: 12


### PR DESCRIPTION
## Summary
- drop the initialDelaySeconds setting from the Keycloak startup probe because the CRD schema rejects it
- document in-line that we rely on a higher failure threshold until the operator exposes an initial delay knob

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d4e5dd7b98832b8b71e69b0072fd22