### PR TITLE
Ensure midpoint seeder job is re-created after failures

### DIFF
--- a/k8s/apps/midpoint/seeder-job.yaml
+++ b/k8s/apps/midpoint/seeder-job.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: iam
   annotations:
     argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,HookFailed
     argocd.argoproj.io/sync-wave: "20"
 spec:
   template:


### PR DESCRIPTION
## Summary
- update the midpoint seeder hook to delete failed Job runs automatically so Argo CD can recreate it on the next sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d52f6d71d0832b99581e37a68cc8da