### PR TITLE
Add midPoint readiness probe to delay PostSync seeding until login is available

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -498,6 +498,18 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          # Wait for the midPoint web application to serve the login page before
+          # marking the pod Ready so Argo CD defers PostSync hooks (e.g. the
+          # midpoint-seeder Job) until the REST API is responsive.
+          readinessProbe:
+            httpGet:
+              path: /midpoint/login
+              port: http
+            failureThreshold: 12
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
           envFrom:
             - configMapRef:
                 name: midpoint-env


### PR DESCRIPTION
## Summary
- add an HTTP readiness probe to the midPoint deployment so the pod only reports Ready once the login page is served
- document in-line that this defers Argo CD PostSync hooks (midpoint-seeder) until the REST API responds

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d54c6684cc832bbb228d758e759d51