### PR TITLE
Fix midPoint seed objects to use stable OIDs

### DIFF
--- a/k8s/apps/midpoint/objects/01_org_rws.xml
+++ b/k8s/apps/midpoint/objects/01_org_rws.xml
@@ -1,5 +1,6 @@
 <object xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3">
   <org>
+    <oid>11111111-1111-1111-1111-111111111111</oid>
     <name>RWS</name>
     <displayName>Rijkswaterstaat</displayName>
     <identifier>ORG-RWS</identifier>

--- a/k8s/apps/midpoint/objects/02_role_project_admin.xml
+++ b/k8s/apps/midpoint/objects/02_role_project_admin.xml
@@ -1,5 +1,6 @@
 <object xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3">
   <role>
+    <oid>22222222-2222-2222-2222-222222222222</oid>
     <name>Project Admin</name>
     <description>Role that grants project-admin permissions in the demo.</description>
     <policyRule>

--- a/k8s/apps/midpoint/objects/03_org_architects.xml
+++ b/k8s/apps/midpoint/objects/03_org_architects.xml
@@ -1,5 +1,6 @@
 <object xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3">
   <org>
+    <oid>33333333-3333-3333-3333-333333333333</oid>
     <name>Architects</name>
     <displayName>Architecten</displayName>
     <identifier>ORG-ARCH</identifier>

--- a/k8s/apps/midpoint/objects/04_user_director.xml
+++ b/k8s/apps/midpoint/objects/04_user_director.xml
@@ -1,5 +1,6 @@
 <object xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3">
   <user>
+    <oid>44444444-4444-4444-4444-444444444444</oid>
     <name>director1</name>
     <fullName>Directeur Demo</fullName>
     <givenName>Directeur</givenName>

--- a/k8s/apps/midpoint/objects/05_user_architect1.xml
+++ b/k8s/apps/midpoint/objects/05_user_architect1.xml
@@ -1,12 +1,13 @@
 <object xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3">
   <user>
+    <oid>55555555-5555-5555-5555-555555555555</oid>
     <name>architect1</name>
     <fullName>Architect Demo</fullName>
     <activation>
       <administrativeStatus>enabled</administrativeStatus>
     </activation>
     <assignment>
-      <targetRef oid="ORG-ARCH" type="OrgType"/>
+      <targetRef oid="33333333-3333-3333-3333-333333333333" type="OrgType"/>
     </assignment>
   </user>
 </object>

--- a/k8s/apps/midpoint/objects/06_user_po1.xml
+++ b/k8s/apps/midpoint/objects/06_user_po1.xml
@@ -1,5 +1,6 @@
 <object xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3">
   <user>
+    <oid>66666666-6666-6666-6666-666666666666</oid>
     <name>po1</name>
     <fullName>Product Owner Demo</fullName>
     <activation>

--- a/k8s/apps/midpoint/objects/07_user_dev1.xml
+++ b/k8s/apps/midpoint/objects/07_user_dev1.xml
@@ -1,5 +1,6 @@
 <object xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3">
   <user>
+    <oid>77777777-7777-7777-7777-777777777777</oid>
     <name>dev1</name>
     <fullName>Developer Demo</fullName>
     <activation>


### PR DESCRIPTION
## Summary
- assign fixed OIDs to each midPoint seed object so Argo CD's seeder job can reference the Architects org and treat re-runs as idempotent

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d54c6684cc832bbb228d758e759d51