### PR TITLE
Fix midpoint seeder auth by reading username secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
 
 - Argo CD now runs the `midpoint-seeder` Job as a **PostSync hook** after the IAM application becomes healthy.
   The hook mounts the XML definitions from `k8s/apps/midpoint/objects/` through the `midpoint-objects` ConfigMap
-  and imports them into midPoint via its REST API using the admin password in the `midpoint-admin` Secret.
+  and imports them into midPoint via its REST API using the admin credentials from the `midpoint-admin` Secret
+  (it now consumes both `username` and `password`, defaulting to `administrator` only when the secret omits a username).
 - The Job treats existing objects as a no-op (HTTP 409), so repeated Argo CD syncs keep the demo state convergent
   without failing when objects already exist.
 - To re-run the import manually, trigger an Argo CD sync or delete the completed `midpoint-seeder` Job and Argo CD

--- a/k8s/apps/midpoint/seeder-job.yaml
+++ b/k8s/apps/midpoint/seeder-job.yaml
@@ -41,7 +41,17 @@ spec:
                 exit 1
               fi
 
+              username_file="/var/run/secrets/midpoint-admin/username"
+              if [ -z "${MIDPOINT_USERNAME:-}" ] && [ -r "${username_file}" ]; then
+                MIDPOINT_USERNAME="$(tr -d '\r\n' <"${username_file}")"
+              fi
+
               midpoint_username="${MIDPOINT_USERNAME:-administrator}"
+
+              if [ -z "${midpoint_username}" ]; then
+                echo "ERROR: midpoint admin username could not be determined" >&2
+                exit 1
+              fi
               MP_URL="${MIDPOINT_URL:-http://midpoint:8080/midpoint}"
               echo "Using midPoint at: $MP_URL"
 


### PR DESCRIPTION
## Summary
- teach the midpoint-seeder hook to read the admin username from the midpoint-admin secret when present
- guard against missing usernames and document the change in the README so operators know both secret keys are used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d553f9ea64832ba51201c88fcca89e