### PR TITLE
Align midPoint admin username with secret

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -516,6 +516,12 @@ spec:
           env:
             - name: MP_SET_midpoint_administrator_initialPassword_FILE
               value: /var/run/secrets/midpoint-admin/password
+            - name: MP_SET_midpoint_administrator_userId
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-admin
+                  key: username
+                  optional: true
             - name: MP_MEM_INIT
               value: "768M"
             - name: MP_MEM_MAX


### PR DESCRIPTION
## Summary
- configure the midPoint deployment to set the administrator userId from the midpoint-admin secret so automation uses the same credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d557d1203c832b84a5ee1e8203f4c5