### PR TITLE
Fix midPoint admin password injection

### DIFF
--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -514,8 +514,11 @@ spec:
             - configMapRef:
                 name: midpoint-env
           env:
-            - name: MP_SET_midpoint_administrator_initialPassword_FILE
-              value: /var/run/secrets/midpoint-admin/password
+            - name: MP_SET_midpoint_administrator_initialPassword
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-admin
+                  key: password
             - name: MP_SET_midpoint_administrator_userId
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- set the midPoint deployment to read the administrator password directly from the midpoint-admin secret so the running pod uses the same credentials as the seeder job

## Testing
- not run (infrastructure-specific change)


------
https://chatgpt.com/codex/tasks/task_e_68d55bc17458832bb724b05c72a1baa5