### PR TITLE
Ensure midPoint admin credentials are applied consistently

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -1238,6 +1238,7 @@ jobs:
           set -euo pipefail
 
           kubectl -n ${{ inputs.NAMESPACE_IAM }} create secret generic midpoint-admin \
+            --from-literal=username=administrator \
             --from-literal=password="$MIDPOINT_ADMIN_PASSWORD" \
             --dry-run=client -o yaml | kubectl apply -f -
       - name: Wait for Keycloak operator CRDs

--- a/k8s/apps/midpoint/deployment.yaml
+++ b/k8s/apps/midpoint/deployment.yaml
@@ -514,8 +514,11 @@ spec:
             - configMapRef:
                 name: midpoint-env
           env:
-            - name: MP_SET_midpoint_administrator_initialPassword_FILE
-              value: /var/run/secrets/midpoint-admin/password
+            - name: MP_SET_midpoint_administrator_initialPassword
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-admin
+                  key: password
             - name: MP_SET_midpoint_administrator_userId
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- load the midPoint administrator password straight from the midpoint-admin secret so the container respects the Git-managed secret
- create the midpoint-admin secret with an explicit administrator username so downstream jobs can mount both credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d55bc17458832bb724b05c72a1baa5