### PR TITLE
Bootstrap namespaces via GitOps

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -46,16 +46,11 @@ jobs:
           resource-group: ${{ inputs.RESOURCE_GROUP }}
           cluster-name: ${{ inputs.AKS_NAME }}
 
-      - name: Create namespaces
+      - name: Ensure Argo CD namespace exists
         shell: bash
         run: |
           set -euo pipefail
-          kubectl create ns argocd --dry-run=client -o yaml | kubectl apply -f -
-          kubectl create ns ingress-nginx --dry-run=client -o yaml | kubectl apply -f -
-          kubectl create ns cert-manager --dry-run=client -o yaml | kubectl apply -f -
-          kubectl create ns keycloak --dry-run=client -o yaml | kubectl apply -f -
-          kubectl create ns cnpg-system --dry-run=client -o yaml | kubectl apply -f -
-          kubectl create ns ${{ inputs.NAMESPACE_IAM }} --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f k8s/argocd/namespace.yaml
 
       - name: Install Argo CD (stable manifest)
         shell: bash

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
    - Create a Kubernetes **Secret** with Azure Blob credentials (from repo secrets) for CNPG backups
    - Purge any existing WAL/archive blobs in the Azure `cnpg-backups/iam-db` prefix so CloudNativePG can bootstrap cleanly on reruns
    - The workflow now waits on the `apps` application by calling `argocd --core app wait --sync --health`, so you see Argo CD's native status output instead of bespoke polling. If reconciliation stalls, the CLI output highlights the objects Argo CD still considers out of sync.
-   - Both Argo CD Applications now track the explicit **`main`** branch (instead of the symbolic `HEAD` ref) so the repo server refreshes to the latest commit as soon as you push. If you promote changes from another branch, update the manifests' `targetRevision` fields accordingly before running the workflow.
-   - Argo CD ships with a custom health script for the Keycloak operator's CRDs (`Keycloak` and `KeycloakRealmImport`). The controller now marks those resources `Healthy` once the operator reports `status.ready=true`/`status.phase=Done`, so `argocd app wait --health` no longer stalls even though the pods respond to `/health/ready` on the management port.
+    - Both Argo CD Applications now track the explicit **`main`** branch (instead of the symbolic `HEAD` ref) so the repo server refreshes to the latest commit as soon as you push. If you promote changes from another branch, update the manifests' `targetRevision` fields accordingly before running the workflow.
+    - Addon and workload namespaces now originate exclusively from the Git-managed manifests. The bootstrap workflow stops creating them with imperative `kubectl create ns` calls and relies on Argo CD's `CreateNamespace=true` sync option to keep namespace state declarative.
+    - Argo CD ships with a custom health script for the Keycloak operator's CRDs (`Keycloak` and `KeycloakRealmImport`). The controller now marks those resources `Healthy` once the operator reports `status.ready=true`/`status.phase=Done`, so `argocd app wait --health` no longer stalls even though the pods respond to `/health/ready` on the management port.
 
 > By default, services are plain HTTP for simplicity and use **`nip.io`** hostnames you can visit from your browser.
 

--- a/k8s/argocd/namespace.yaml
+++ b/k8s/argocd/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+  labels:
+    app.kubernetes.io/name: argocd
+    app.kubernetes.io/part-of: argocd


### PR DESCRIPTION
## Summary
- apply the Argo CD namespace manifest from Git instead of creating namespaces imperatively in the bootstrap workflow
- add a tracked argocd namespace definition for kubectl apply to consume during bootstrap
- document that addon and workload namespaces now rely on Argo CD's CreateNamespace option instead of kubectl create

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d55e99497c832b9612e73a1882e98f