### PR TITLE
Ensure IAM namespace is managed declaratively

### DIFF
--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespace.yaml
   - cnpg
   - keycloak/keycloak.yaml
   - keycloak/rws-realm.yaml

--- a/k8s/apps/namespace.yaml
+++ b/k8s/apps/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: iam
+  labels:
+    app.kubernetes.io/managed-by: argocd


### PR DESCRIPTION
## Summary
- add a dedicated Namespace manifest so the iam namespace is created by Argo CD
- include the namespace manifest in the IAM kustomization to guarantee it applies before other resources

## Testing
- python3 scripts/check_keycloak_first_class_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68d5648e947c832b85301e7367c53a8b