### PR TITLE
Unset conflicting midPoint admin _FILE env vars

### DIFF
--- a/k8s/apps/midpoint/kustomization.yaml
+++ b/k8s/apps/midpoint/kustomization.yaml
@@ -26,6 +26,8 @@ configMapGenerator:
       - MP_UNSET_midpoint_repository_jdbcPassword=1
       - MP_UNSET_midpoint_repository_username=1
       - MP_UNSET_midpoint_repository_password=1
+      - MP_UNSET_midpoint_administrator_initialPassword_FILE=1
+      - MP_UNSET_midpoint_administrator_userId_FILE=1
       - MIDPOINT_DB_HOST=iam-db-rw.iam.svc.cluster.local
       - MIDPOINT_DB_PORT=5432
       - MIDPOINT_DB_NAME=midpoint


### PR DESCRIPTION
## Summary
- ensure the midpoint deployment clears the *_FILE variants of the administrator bootstrap variables so the *_value secrets win

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d567ee7584832bbceb80ff09ca9a83