### PR TITLE
Ensure keycloak operator runs in its namespace

### DIFF
--- a/k8s/addons/keycloak-operator/kustomization.yaml
+++ b/k8s/addons/keycloak-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: keycloak
 resources:
+  - namespace.yaml
   - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.3.4/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
   - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.3.4/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
   - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.3.4/kubernetes/kubernetes.yml

--- a/k8s/addons/keycloak-operator/namespace.yaml
+++ b/k8s/addons/keycloak-operator/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+  labels:
+    app.kubernetes.io/managed-by: argocd


### PR DESCRIPTION
## Summary
- configure the keycloak-operator kustomization to render namespaced resources into the keycloak namespace
- add a managed Namespace manifest so Argo CD can create the keycloak namespace before deploying the operator

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5795ae9d8832b86a8ac6cbcf92f5b