### PR TITLE
Disable forced TLS on midPoint ingress

### DIFF
--- a/k8s/apps/midpoint/ingress.yaml
+++ b/k8s/apps/midpoint/ingress.yaml
@@ -4,6 +4,12 @@ metadata:
   name: midpoint
   namespace: iam
   annotations:
+    # midPoint only exposes plain HTTP on port 8080. Ensure ingress-nginx
+    # keeps the backend connection unencrypted and does not attempt to force
+    # HTTPS on incoming requests so the demo can stay HTTP-only unless TLS is
+    # explicitly configured via Git.
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-body-size: "16m"
 spec:
   # Default ingress class/host values are overridden by kustomize replacements


### PR DESCRIPTION
## Summary
- disable nginx SSL redirection for the midPoint ingress so the HTTP-only demo works without TLS
- force the controller to talk HTTP to the midPoint service and document the rationale in the manifest

## Testing
- python3 scripts/check_keycloak_first_class_fields.py


------
https://chatgpt.com/codex/tasks/task_e_68d588b3496c832b82f7c96f38b5a7f6