### PR TITLE
Disable forced SSL redirect on Keycloak ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ End-to-end demo that deploys **AKS**, **Argo CD**, **Ingress-NGINX**, **cert-man
     fields as the first-class citizen of the CR: features,hostname-strict,db-url`, double-check that no overrides reintroduced
     those CLI switches—Keycloak will crash-loop with that configuration.
   - The operator-managed Ingress defaults to routing traffic to Keycloak over HTTPS. The demo keeps the public endpoints on
-    plain HTTP for simplicity, so the manifest overrides the controller annotation to use an HTTP backend and disables the
-    automatic SSL redirect. Without this change ingress-nginx attempts an HTTPS handshake with Keycloak, never receives a
-    response, and the published `kc.<IP>.nip.io` URL times out even though the pods are healthy.
+    plain HTTP for simplicity, so the manifest overrides the controller annotation to use an HTTP backend and disables both of
+    the ingress-nginx SSL redirect toggles. Without this change ingress-nginx attempts an HTTPS handshake with Keycloak, never
+    receives a response, and the published `kc.<IP>.nip.io` URL times out even though the pods are healthy.
 
 - **midPoint config**: `k8s/apps/midpoint/deployment.yaml` + `k8s/apps/midpoint/config.xml`
   - The deployment constrains the JVM heap (`MP_MEM_INIT=768M`, `MP_MEM_MAX=1536M`) to keep resource usage predictable.

--- a/k8s/apps/keycloak/keycloak.yaml
+++ b/k8s/apps/keycloak/keycloak.yaml
@@ -78,6 +78,7 @@ spec:
     # routing through ingress-nginx.
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
   resources:
     requests:


### PR DESCRIPTION
## Summary
- ensure the Keycloak operator-managed ingress disables both SSL redirect knobs so HTTP works with ingress-nginx
- document the additional ingress-nginx annotation in the Keycloak configuration guidance

## Testing
- python3 scripts/check_keycloak_first_class_fields.py
- kustomize build k8s/apps | kubeconform --strict --ignore-missing-schemas


------
https://chatgpt.com/codex/tasks/task_e_68d588b3496c832b82f7c96f38b5a7f6