### PR TITLE
Allow keycloak operator to watch network policies

### DIFF
--- a/k8s/addons/keycloak-operator/kustomization.yaml
+++ b/k8s/addons/keycloak-operator/kustomization.yaml
@@ -29,3 +29,10 @@ patches:
                     value: iam,keycloak
                   - name: QUARKUS_OPERATOR_SDK_GENERATE_WITH_WATCHED_NAMESPACES
                     value: iam,keycloak
+patchesJson6902:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: keycloakcontroller-cluster-role
+    path: patch-clusterrole-networkpolicies.yaml

--- a/k8s/addons/keycloak-operator/patch-clusterrole-networkpolicies.yaml
+++ b/k8s/addons/keycloak-operator/patch-clusterrole-networkpolicies.yaml
@@ -1,0 +1,15 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
## Summary
- allow the keycloak operator cluster role patch to be extended via kustomize
- ensure the operator receives network policy permissions in watched namespaces

## Testing
- `kustomize build k8s/addons/keycloak-operator` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5870511ec832b980c9cbb05729481