### PR TITLE
Fix secrets check in Argo CD bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -26,6 +26,9 @@ permissions:
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
+    env:
+      ARGOCD_REPO_USERNAME: ${{ secrets.ARGOCD_REPO_USERNAME }}
+      ARGOCD_REPO_TOKEN: ${{ secrets.ARGOCD_REPO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -59,12 +62,12 @@ jobs:
           kubectl -n argocd rollout status statefulset/argocd-application-controller --timeout=300s
 
       - name: Configure Argo CD repository credentials (private repos only)
-        if: ${{ secrets.ARGOCD_REPO_USERNAME != '' && secrets.ARGOCD_REPO_TOKEN != '' }}
+        if: ${{ env.ARGOCD_REPO_USERNAME != '' && env.ARGOCD_REPO_TOKEN != '' }}
         shell: bash
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          ARGOCD_REPO_USERNAME: ${{ secrets.ARGOCD_REPO_USERNAME }}
-          ARGOCD_REPO_TOKEN: ${{ secrets.ARGOCD_REPO_TOKEN }}
+          ARGOCD_REPO_USERNAME: ${{ env.ARGOCD_REPO_USERNAME }}
+          ARGOCD_REPO_TOKEN: ${{ env.ARGOCD_REPO_TOKEN }}
         run: |
           set -euo pipefail
           owner="${GITHUB_REPOSITORY%%/*}"


### PR DESCRIPTION
## Summary
- expose the Argo CD repository credentials secrets as job environment variables
- gate the repository credential step on the environment values so workflows can validate the expression

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d592b77678832babc67c9c5c3a6519