### PR TITLE
Fix Argo CD configmap patch namespace

### DIFF
--- a/gitops/clusters/aks/bootstrap/argocd-cm-patch.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-cm-patch.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cm
-  namespace: argocd
   labels:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd

--- a/gitops/clusters/aks/bootstrap/kustomization.yaml
+++ b/gitops/clusters/aks/bootstrap/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: argocd
 resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.1.7/manifests/install.yaml
 patches:


### PR DESCRIPTION
## Summary
- remove the namespace qualifier from the Argo CD configmap strategic merge patch so it can match the upstream manifest
- set the bootstrap kustomization namespace to argocd so rendered resources land in the expected namespace

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5944dabb0832b9192dae2d7386685