### PR TITLE
Trim manifest verbosity while preserving behavior

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -8,43 +8,20 @@ spec:
   instances: 1
   startOptimized: false
   additionalOptions:
-    # Only keep CLI toggles that are still missing strongly typed equivalents in
-    # the v2alpha1 Keycloak CR. Hostname strictness and the database URL now rely
-    # on the dedicated spec fields instead of the legacy CLI overrides.
-    # Enable Quarkus health/metrics endpoints so Kubernetes and the operator
-    # can call `/health/ready` during startup and surface Keycloak readiness to
-    # Argo CD's health checks.
     - name: health-enabled
       value: "true"
     - name: metrics-enabled
       value: "true"
-    # Keycloak still lacks a typed knob for KC_HOSTNAME_STRICT_HTTPS, so retain
-    # the CLI switch to allow the demo ingress to terminate TLS in front of the
-    # pod while the runtime continues to serve plain HTTP.
     - name: hostname-strict-https
       value: "false"
-  # Pin the operator's feature list to a known good entry so it does not inject
-  # the legacy "health" feature into KC_FEATURES. Keycloak 26 removed that flag
-  # and will crash if we request it, so we enable the health endpoints via
-  # KC_HEALTH_ENABLED instead. The operator still adds "health" when the
-  # enabled list is empty, so explicitly enable a harmless feature to keep
-  # KC_FEATURES stable.
   features:
     enabled:
       - token-exchange
   db:
-    # Drive the database configuration through the strongly typed fields so the
-    # operator does not have to fall back to the deprecated CLI flags (Keycloak
-    # 26.x fails hard when `--db-url` is provided). CloudNativePG defaults to
-    # TLS and Keycloak negotiates it automatically, so the generated JDBC URL
-    # works without extra query parameters.
     vendor: postgres
     host: iam-db-rw.iam.svc.cluster.local
     port: 5432
     database: keycloak
-    # Keycloak defaults to the "public" schema when connecting to PostgreSQL.
-    # Declare it explicitly so future operator releases do not infer a schema
-    # switch that would force us back to the deprecated `--db-url` CLI flag.
     schema: public
     usernameSecret:
       name: keycloak-db-app
@@ -55,27 +32,12 @@ spec:
   http:
     httpEnabled: true
   hostname:
-    # Default hostname is overridden by kustomize replacements using values
-    # from k8s/apps/params.env during the build.
     hostname: kc.127.0.0.1.nip.io
-    # Allow the demo ingress to terminate HTTP without Keycloak rejecting the
-    # host/scheme. The nip.io address changes every time the AKS load balancer
-    # IP changes, so keep hostname checks disabled via the typed spec field
-    # instead of the deprecated CLI toggle.
     strict: false
-    # Relax backchannel hostname verification with the strongly typed knob so
-    # we do not have to fall back to the legacy `--hostname-strict` CLI flag
-    # that Keycloak 26 rejects.
     strictBackchannel: false
   ingress:
     enabled: true
-    # Ingress class is overridden at build time by kustomize replacements using
-    # the Git-managed value in k8s/apps/params.env. The configure_demo_hosts
-    # workflow only updates the hosts so the class stays declarative.
     className: nginx
-    # Force the operator-managed ingress to proxy Keycloak over HTTP. The
-    # operator defaults to HTTPS backends, which breaks the demo's plain-HTTP
-    # routing through ingress-nginx.
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
@@ -87,14 +49,6 @@ spec:
     limits:
       cpu: "1"
       memory: "2Gi"
-  # The v2alpha1 CRD now provides a typed `spec.startupProbe`. The controller
-  # rejects unknown fields when reconciling through Server-Side Apply, so keep
-  # the probe configuration inside the supported schema rather than the
-  # `unsupported.podTemplate` escape hatch. The operator still defaults to the
-  # management port, but enabling the Quarkus health endpoints above keeps the
-  # `/health/ready` handler available during bootstrap. The CRD currently lacks
-  # an `initialDelaySeconds` knob, so we rely on a more permissive probe
-  # threshold to keep Keycloak alive while it performs the initial augmentation.
   startupProbe:
     periodSeconds: 5
     failureThreshold: 12

--- a/gitops/apps/iam/midpoint/deployment.yaml
+++ b/gitops/apps/iam/midpoint/deployment.yaml
@@ -498,9 +498,6 @@ spec:
           ports:
             - name: http
               containerPort: 8080
-          # Wait for the midPoint web application to serve the login page before
-          # marking the pod Ready so Argo CD defers PostSync hooks (e.g. the
-          # midpoint-seeder Job) until the REST API is responsive.
           readinessProbe:
             httpGet:
               path: /midpoint/login

--- a/gitops/apps/iam/midpoint/ingress.yaml
+++ b/gitops/apps/iam/midpoint/ingress.yaml
@@ -4,18 +4,10 @@ metadata:
   name: midpoint
   namespace: iam
   annotations:
-    # midPoint only exposes plain HTTP on port 8080. Ensure ingress-nginx
-    # keeps the backend connection unencrypted and does not attempt to force
-    # HTTPS on incoming requests so the demo can stay HTTP-only unless TLS is
-    # explicitly configured via Git.
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-body-size: "16m"
 spec:
-  # Default ingress class/host values are overridden by kustomize replacements
-  # at build time using the values from k8s/apps/params.env. The helper workflow
-  # only rotates the hosts; change ingressClass in Git when targeting a
-  # different controller.
   ingressClassName: nginx
   rules:
     - host: mp.127.0.0.1.nip.io

--- a/gitops/apps/iam/midpoint/kustomization.yaml
+++ b/gitops/apps/iam/midpoint/kustomization.yaml
@@ -1,50 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 namespace: iam
 
-resources:
-  - deployment.yaml
-  - ingress.yaml
-  - seeder-job.yaml
+resources: [deployment.yaml, ingress.yaml, seeder-job.yaml]
+
+generatorOptions:
+  disableNameSuffixHash: true
 
 configMapGenerator:
   - name: midpoint-config
-    files:
-      - config.xml
-    options:
-      disableNameSuffixHash: true
+    files: [config.xml]
   - name: midpoint-env
-    literals:
-      - MP_NO_ENV_COMPAT=1
-      - MP_UNSET_midpoint_repository_database=1
-      - MP_UNSET_midpoint_repository_jdbcUrl=1
-      - MP_UNSET_midpoint_repository_hibernateHbm2ddl=1
-      - MP_UNSET_midpoint_repository_initializationFailTimeout=1
-      - MP_UNSET_midpoint_repository_missingSchemaAction=1
-      - MP_UNSET_midpoint_repository_upgradeableSchemaAction=1
-      - MP_UNSET_midpoint_repository_jdbcUsername=1
-      - MP_UNSET_midpoint_repository_jdbcPassword=1
-      - MP_UNSET_midpoint_repository_username=1
-      - MP_UNSET_midpoint_repository_password=1
-      - MP_UNSET_midpoint_administrator_initialPassword_FILE=1
-      - MP_UNSET_midpoint_administrator_userId_FILE=1
-      - MIDPOINT_DB_HOST=iam-db-rw.iam.svc.cluster.local
-      - MIDPOINT_DB_PORT=5432
-      - MIDPOINT_DB_NAME=midpoint
-      - MIDPOINT_DB_WAIT_MAX_ATTEMPTS=60
-      - MIDPOINT_DB_WAIT_SLEEP_SECONDS=5
-    options:
-      disableNameSuffixHash: true
+    literals: [MP_NO_ENV_COMPAT=1, MP_UNSET_midpoint_repository_database=1, MP_UNSET_midpoint_repository_jdbcUrl=1, MP_UNSET_midpoint_repository_hibernateHbm2ddl=1, MP_UNSET_midpoint_repository_initializationFailTimeout=1, MP_UNSET_midpoint_repository_missingSchemaAction=1, MP_UNSET_midpoint_repository_upgradeableSchemaAction=1, MP_UNSET_midpoint_repository_jdbcUsername=1, MP_UNSET_midpoint_repository_jdbcPassword=1, MP_UNSET_midpoint_repository_username=1, MP_UNSET_midpoint_repository_password=1, MP_UNSET_midpoint_administrator_initialPassword_FILE=1, MP_UNSET_midpoint_administrator_userId_FILE=1, MIDPOINT_DB_HOST=iam-db-rw.iam.svc.cluster.local, MIDPOINT_DB_PORT=5432, MIDPOINT_DB_NAME=midpoint, MIDPOINT_DB_WAIT_MAX_ATTEMPTS=60, MIDPOINT_DB_WAIT_SLEEP_SECONDS=5]
   - name: midpoint-objects
-    files:
-      - objects/01_org_rws.xml
-      - objects/02_role_project_admin.xml
-      - objects/03_org_architects.xml
-      - objects/04_user_director.xml
-      - objects/05_user_architect1.xml
-      - objects/06_user_po1.xml
-      - objects/07_user_dev1.xml
-    options:
-      disableNameSuffixHash: true
+    files: [objects/01_org_rws.xml, objects/02_role_project_admin.xml, objects/03_org_architects.xml, objects/04_user_director.xml, objects/05_user_architect1.xml, objects/06_user_po1.xml, objects/07_user_dev1.xml]

--- a/gitops/apps/iam/midpoint/seeder-job.yaml
+++ b/gitops/apps/iam/midpoint/seeder-job.yaml
@@ -125,21 +125,6 @@ spec:
         - name: objs
           configMap:
             name: midpoint-objects
-            items:
-              - key: 01_org_rws.xml
-                path: 01_org_rws.xml
-              - key: 02_role_project_admin.xml
-                path: 02_role_project_admin.xml
-              - key: 03_org_architects.xml
-                path: 03_org_architects.xml
-              - key: 04_user_director.xml
-                path: 04_user_director.xml
-              - key: 05_user_architect1.xml
-                path: 05_user_architect1.xml
-              - key: 06_user_po1.xml
-                path: 06_user_po1.xml
-              - key: 07_user_dev1.xml
-                path: 07_user_dev1.xml
         - name: midpoint-admin-secret
           secret:
             secretName: midpoint-admin


### PR DESCRIPTION
## Summary
- remove verbose commentary from Keycloak and midPoint manifests while keeping declarative state unchanged
- rely on generatorOptions and inline lists to collapse kustomize generators and volumes without affecting rendered output
- drop redundant configmap volume items to let Kubernetes mount all midPoint object definitions by default

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d594c95c7c832b8cc7783b935e3d0b