### PR TITLE
Ensure Argo CD namespace exists during bootstrap

### DIFF
--- a/gitops/clusters/aks/bootstrap/kustomization.yaml
+++ b/gitops/clusters/aks/bootstrap/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd
 resources:
+  - namespace.yaml
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.1.7/manifests/install.yaml
 patches:
   - path: argocd-cm-patch.yaml

--- a/gitops/clusters/aks/bootstrap/namespace.yaml
+++ b/gitops/clusters/aks/bootstrap/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+  labels:
+    app.kubernetes.io/name: argocd
+    app.kubernetes.io/part-of: argocd


### PR DESCRIPTION
## Summary
- add an argocd namespace manifest to the bootstrap kustomization
- include the namespace manifest in the resource list so the namespace is created before other components

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59916a7e0832b968555d3956a174d