### PR TITLE
Automate CNPG storage account configuration in bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -82,31 +82,24 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
           kubectl -n argocd label secret "${secret_name}" argocd.argoproj.io/secret-type=repository --overwrite
 
-      - name: Validate CNPG storage account configuration
+      - name: Render CNPG storage account configuration
         shell: bash
         env:
           STORAGE_ACCOUNT_INPUT: ${{ inputs.STORAGE_ACCOUNT }}
         run: |
           set -euo pipefail
           config_file="gitops/apps/iam/cnpg/params.env"
-          if [ ! -f "${config_file}" ]; then
-            echo "${config_file} is missing. Commit it with the Terraform storage account output before running this workflow."
-            exit 1
-          fi
-          storage_account_git=$(grep -E '^storageAccount=' "${config_file}" | tail -n1 | cut -d'=' -f2- | tr -d ' \t\r\n')
-          if [ -z "${storage_account_git}" ] || [ "${storage_account_git}" = "changeme" ]; then
-            echo "storageAccount in ${config_file} must be set to the Terraform storage_account_name output."
-            exit 1
-          fi
           storage_account_input=$(printf '%s' "${STORAGE_ACCOUNT_INPUT}" | tr -d ' \t\r\n')
           if [ -z "${storage_account_input}" ]; then
             echo "STORAGE_ACCOUNT input must not be empty."
             exit 1
           fi
-          if [ "${storage_account_git,,}" != "${storage_account_input,,}" ]; then
-            echo "storageAccount (${storage_account_git}) does not match workflow input (${storage_account_input})."
-            exit 1
-          fi
+          tmp_file=$(mktemp)
+          cat >"${tmp_file}" <<EOF
+# storageAccount is set by the bootstrap workflow from the STORAGE_ACCOUNT input.
+storageAccount=${storage_account_input}
+EOF
+          mv "${tmp_file}" "${config_file}"
 
       - name: Create IAM namespace early
         shell: bash

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ requirements-dev.txt     # Python tooling for unit tests and scripts
    - *(optional, only for private repositories)* `ARGOCD_REPO_USERNAME` and `ARGOCD_REPO_TOKEN`
 4. Update the GitOps configuration:
    - Set `data.repoURL` (and optionally `data.targetRevision`) in [`gitops/clusters/aks/context.yaml`](gitops/clusters/aks/context.yaml) to point at **your** repository.
-   - Replace the placeholder storage account value in [`gitops/apps/iam/cnpg/params.env`](gitops/apps/iam/cnpg/params.env) with the `storage_account_name` Terraform output before bootstrapping.
+   - Provide the CloudNativePG backup storage account to the bootstrap workflow via its `STORAGE_ACCOUNT` input (the workflow now writes [`gitops/apps/iam/cnpg/params.env`](gitops/apps/iam/cnpg/params.env) for you).
 
 ## 1. Provision AKS with Terraform
 
@@ -38,8 +38,7 @@ Trigger the workflow **“01 - Provision AKS with Terraform”** (`.github/wor
 
 ## 2. Bootstrap Argo CD and the demo stack
 
-1. Ensure [`gitops/apps/iam/cnpg/params.env`](gitops/apps/iam/cnpg/params.env) contains the Terraform storage account name.
-2. Run the workflow **“02 - Bootstrap GitOps stack”** (`.github/workflows/02_bootstrap_argocd.yml`). It will:
+1. Run the workflow **“02 - Bootstrap GitOps stack”** (`.github/workflows/02_bootstrap_argocd.yml`). Provide the `STORAGE_ACCOUNT` input so the job can render the CNPG backup configuration. It will:
    - Apply the Argo CD bootstrap kustomization pinned to `v3.1.7`.
    - Optionally configure repository credentials when the repo is private.
    - Create the database and admin secrets in the `iam` namespace.

--- a/gitops/apps/iam/cnpg/params.env
+++ b/gitops/apps/iam/cnpg/params.env
@@ -1,3 +1,2 @@
-# storageAccount must match the Azure Storage account created by Terraform for CNPG backups.
-# Update this value with the terraform output `storage_account_name` before bootstrapping the cluster.
-storageAccount=changeme
+# storageAccount is set by the bootstrap workflow from the STORAGE_ACCOUNT input.
+storageAccount=__SET_BY_BOOTSTRAP_WORKFLOW__


### PR DESCRIPTION
## Summary
- generate the CloudNativePG params.env file from the STORAGE_ACCOUNT workflow input instead of requiring a committed value
- document the new behaviour and remove the changeme placeholder from cnpg params

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5987b60e4832b82e6cb2f00952baf