### PR TITLE
Fix indentation in bootstrap workflow heredoc

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -96,9 +96,9 @@ jobs:
           fi
           tmp_file=$(mktemp)
           cat >"${tmp_file}" <<EOF
-# storageAccount is set by the bootstrap workflow from the STORAGE_ACCOUNT input.
-storageAccount=${storage_account_input}
-EOF
+          # storageAccount is set by the bootstrap workflow from the STORAGE_ACCOUNT input.
+          storageAccount=${storage_account_input}
+          EOF
           mv "${tmp_file}" "${config_file}"
 
       - name: Create IAM namespace early


### PR DESCRIPTION
## Summary
- fix the indentation inside the heredoc in the Argo CD bootstrap workflow so the YAML parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59a8c2314832bb3f8c8e4508f33ee