### PR TITLE
Handle SAS connection strings without protocol

### DIFF
--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -22,3 +22,16 @@ def test_parse_sas_token():
     cred = parse_credential(token, "demoacct")
     assert cred.sas_token == token.lstrip("?")
     assert "SharedAccessSignature=" in cred.connection_string
+
+
+def test_parse_sas_connection_string():
+    raw = (
+        "BlobEndpoint=https://example.blob.core.windows.net/;"
+        "QueueEndpoint=https://example.queue.core.windows.net/;"
+        "SharedAccessSignature=sv=2021-10-04&sig=fake"
+    )
+    cred = parse_credential(raw, "demoacct")
+    assert cred.storage_account == "demoacct"
+    assert cred.sas_token == "sv=2021-10-04&sig=fake"
+    assert "BlobEndpoint=https://example.blob.core.windows.net/" in cred.connection_string
+    assert "QueueEndpoint=https://example.queue.core.windows.net/" in cred.connection_string


### PR DESCRIPTION
## Summary
- detect Azure Storage SAS connection strings that omit DefaultEndpointsProtocol and normalize them
- retain endpoint information when rebuilding the connection string
- add regression test covering SAS connection string parsing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59b5a4500832b8559909c5d926465