### PR TITLE
Handle quoted Azure storage credentials

### DIFF
--- a/scripts/normalize_azure_storage_secret.py
+++ b/scripts/normalize_azure_storage_secret.py
@@ -18,6 +18,10 @@ class AzureCredential:
 
 def parse_credential(raw: str, storage_account: str) -> AzureCredential:
     value = raw.strip()
+    if (value.startswith("\"") and value.endswith("\"")) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        value = value[1:-1].strip()
     if not value:
         raise ValueError("Credential must not be empty")
 

--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -9,6 +9,11 @@ def test_parse_account_key():
     assert cred.sas_token is None
 
 
+def test_parse_account_key_with_quotes():
+    cred = parse_credential('"ZmFrZUFjY291bnRLZXkxMjM0NTY="', "demoacct")
+    assert cred.account_key == "ZmFrZUFjY291bnRLZXkxMjM0NTY="
+
+
 def test_parse_connection_string():
     raw = "DefaultEndpointsProtocol=https;AccountName=cnpgdemo;AccountKey=abcd;EndpointSuffix=core.windows.net"
     cred = parse_credential(raw, "ignored")


### PR DESCRIPTION
## Summary
- strip optional surrounding quotes from Azure storage credentials so quoted secrets are parsed
- add a regression test covering quoted account keys

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59c8b7894832bac74e6e6b0491777