### PR TITLE
Improve SAS token detection

### DIFF
--- a/scripts/normalize_azure_storage_secret.py
+++ b/scripts/normalize_azure_storage_secret.py
@@ -73,7 +73,8 @@ def parse_credential(raw: str, storage_account: str) -> AzureCredential:
         )
 
     token = value.lstrip("?")
-    if token.lower().startswith("sv=") and "sig=" in token:
+    token_lower = token.lower()
+    if "sig=" in token_lower and "sv=" in token_lower:
         connection_string = (
             "DefaultEndpointsProtocol=https;"
             f"AccountName={storage_account};"

--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -24,6 +24,13 @@ def test_parse_sas_token():
     assert "SharedAccessSignature=" in cred.connection_string
 
 
+def test_parse_sas_token_with_different_order():
+    token = "sp=racwdl&st=2024-01-01T00%3A00%3A00Z&se=2024-12-31T23%3A59%3A59Z&sv=2021-10-04&sig=anotherfake"
+    cred = parse_credential(token, "demoacct")
+    assert cred.sas_token == token
+    assert "SharedAccessSignature=" in cred.connection_string
+
+
 def test_parse_sas_connection_string():
     raw = (
         "BlobEndpoint=https://example.blob.core.windows.net/;"


### PR DESCRIPTION
## Summary
- allow SAS token detection regardless of parameter ordering
- add regression coverage for alternate SAS token formats

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59c8b7894832bac74e6e6b0491777