### PR TITLE
Handle newline-delimited Azure connection strings

### DIFF
--- a/scripts/normalize_azure_storage_secret.py
+++ b/scripts/normalize_azure_storage_secret.py
@@ -25,9 +25,10 @@ def parse_credential(raw: str, storage_account: str) -> AzureCredential:
     if not value:
         raise ValueError("Credential must not be empty")
 
-    if ";" in value and "=" in value:
+    normalized_value = value.replace("\r\n", "\n").replace("\r", "\n")
+    if "=" in normalized_value and (";" in normalized_value or "\n" in normalized_value):
         parts: dict[str, tuple[str, str]] = {}
-        for segment in value.split(";"):
+        for segment in re.split(r"[;\n]+", normalized_value):
             if not segment or "=" not in segment:
                 continue
             key, val = segment.split("=", 1)
@@ -86,7 +87,7 @@ def parse_credential(raw: str, storage_account: str) -> AzureCredential:
         )
         return AzureCredential(storage_account=storage_account, connection_string=connection_string, sas_token=token)
 
-    if re.fullmatch(r"[A-Za-z0-9+/=]{20,}" , value):
+    if re.fullmatch(r"[A-Za-z0-9+/=]{20,}", value):
         connection_string = (
             "DefaultEndpointsProtocol=https;"
             f"AccountName={storage_account};"

--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -22,6 +22,14 @@ def test_parse_connection_string():
     assert cred.account_key == "abcd"
 
 
+def test_parse_connection_string_with_newlines():
+    raw = "DefaultEndpointsProtocol=https\nAccountName=cnpgdemo\nAccountKey=abcd\nEndpointSuffix=core.windows.net"
+    cred = parse_credential(raw, "ignored")
+    assert cred.storage_account == "cnpgdemo"
+    assert "AccountName=cnpgdemo" in cred.connection_string
+    assert "EndpointSuffix=core.windows.net" in cred.connection_string
+
+
 def test_parse_sas_token():
     token = "?sv=2021-10-04&ss=bf&srt=sco&sp=rl&sig=fakesignature"
     cred = parse_credential(token, "demoacct")


### PR DESCRIPTION
## Summary
- allow normalize_azure_storage_secret to parse connection strings that are split across newlines
- keep connection string reconstruction logic intact while accepting CRLF input
- cover newline-delimited connection strings with an explicit unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59f9642a0832b9ad32d03bf5746fb