### PR TITLE
Handle single Azure credential key-value pairs

### DIFF
--- a/scripts/normalize_azure_storage_secret.py
+++ b/scripts/normalize_azure_storage_secret.py
@@ -26,7 +26,16 @@ def parse_credential(raw: str, storage_account: str) -> AzureCredential:
         raise ValueError("Credential must not be empty")
 
     normalized_value = value.replace("\r\n", "\n").replace("\r", "\n")
-    if "=" in normalized_value and (";" in normalized_value or "\n" in normalized_value):
+    if "=" in normalized_value and (
+        ";" in normalized_value
+        or "\n" in normalized_value
+        or re.search(
+            r"\b(accountname|accountkey|sharedaccesssignature|defaultendpointsprotocol|"
+            r"blobendpoint|queueendpoint|tableendpoint|fileendpoint|endpointsuffix)=",
+            normalized_value,
+            flags=re.IGNORECASE,
+        )
+    ):
         parts: dict[str, tuple[str, str]] = {}
         for segment in re.split(r"[;\n]+", normalized_value):
             if not segment or "=" not in segment:

--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -30,6 +30,20 @@ def test_parse_connection_string_with_newlines():
     assert "EndpointSuffix=core.windows.net" in cred.connection_string
 
 
+def test_parse_single_account_key_pair():
+    raw = "AccountKey=ZmFrZUFjY291bnRLZXkxMjM0NTY="
+    cred = parse_credential(raw, "demoacct")
+    assert cred.account_key == "ZmFrZUFjY291bnRLZXkxMjM0NTY="
+    assert cred.storage_account == "demoacct"
+
+
+def test_parse_single_sas_pair():
+    raw = "SharedAccessSignature=sv=2021-10-04&sig=fake"
+    cred = parse_credential(raw, "demoacct")
+    assert cred.sas_token == "sv=2021-10-04&sig=fake"
+    assert "SharedAccessSignature=sv=2021-10-04&sig=fake" in cred.connection_string
+
+
 def test_parse_sas_token():
     token = "?sv=2021-10-04&ss=bf&srt=sco&sp=rl&sig=fakesignature"
     cred = parse_credential(token, "demoacct")


### PR DESCRIPTION
## Summary
- allow the Azure credential normalizer to recognise single key=value pairs as connection strings
- cover the new parsing paths for AccountKey and SharedAccessSignature inputs with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5a09bd168832ba67e9a83bfd2f0ea