### PR TITLE
Handle JSON-wrapped Azure storage credentials

### DIFF
--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -69,3 +69,22 @@ def test_parse_sas_connection_string():
     assert cred.sas_token == "sv=2021-10-04&sig=fake"
     assert "BlobEndpoint=https://example.blob.core.windows.net/" in cred.connection_string
     assert "QueueEndpoint=https://example.queue.core.windows.net/" in cred.connection_string
+
+
+def test_parse_connection_string_json_wrapper():
+    raw = '{"connectionString": "DefaultEndpointsProtocol=https;AccountName=cnpgdemo;AccountKey=abcd;EndpointSuffix=core.windows.net"}'
+    cred = parse_credential(raw, "ignored")
+    assert cred.storage_account == "cnpgdemo"
+    assert cred.account_key == "abcd"
+
+
+def test_parse_key_list_json_wrapper():
+    raw = '[{"value": "ZmFrZUFjY291bnRLZXkxMjM0NTY="}]'
+    cred = parse_credential(raw, "demoacct")
+    assert cred.account_key == "ZmFrZUFjY291bnRLZXkxMjM0NTY="
+
+
+def test_parse_key_dict_with_keys_field():
+    raw = '{"keys": [{"value": "ZmFrZUFjY291bnRLZXkxMjM0NTY="}]}'
+    cred = parse_credential(raw, "demoacct")
+    assert cred.account_key == "ZmFrZUFjY291bnRLZXkxMjM0NTY="


### PR DESCRIPTION
## Summary
- allow the Azure storage credential normalizer to unwrap JSON secrets produced by common Azure CLI commands
- add unit tests covering JSON-wrapped connection strings and key lists

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5a2a297fc832b85e26d74632b2719