### PR TITLE
Handle SAS URL inputs in Azure credential normalization

### DIFF
--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -71,6 +71,15 @@ def test_parse_sas_connection_string():
     assert "QueueEndpoint=https://example.queue.core.windows.net/" in cred.connection_string
 
 
+def test_parse_sas_url():
+    token = "sv=2021-10-04&sig=fake"
+    url = f"https://cnpgdemo.blob.core.windows.net/backups?{token}"
+    cred = parse_credential(url, "ignored")
+    assert cred.storage_account == "cnpgdemo"
+    assert cred.sas_token == token
+    assert "BlobEndpoint=https://cnpgdemo.blob.core.windows.net/" in cred.connection_string
+
+
 def test_parse_connection_string_json_wrapper():
     raw = '{"connectionString": "DefaultEndpointsProtocol=https;AccountName=cnpgdemo;AccountKey=abcd;EndpointSuffix=core.windows.net"}'
     cred = parse_credential(raw, "ignored")


### PR DESCRIPTION
## Summary
- handle SAS URL inputs by extracting the shared access signature and storage account
- add coverage for SAS URL parsing in normalize_azure_storage_secret tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5a4e50898832b857d215b4fd96672