### PR TITLE
Support development storage credentials

### DIFF
--- a/scripts/normalize_azure_storage_secret.py
+++ b/scripts/normalize_azure_storage_secret.py
@@ -28,6 +28,14 @@ def parse_credential(raw: str, storage_account: str) -> AzureCredential:
         raise ValueError("Credential must not be empty")
 
     normalized_value = value.replace("\r\n", "\n").replace("\r", "\n")
+
+    if normalized_value.lower().startswith("usedevelopmentstorage=true"):
+        parts = [segment.strip() for segment in re.split(r"[;\n]+", normalized_value) if segment.strip()]
+        connection_string = ";".join(parts)
+        return AzureCredential(
+            storage_account=storage_account,
+            connection_string=connection_string,
+        )
     if "=" in normalized_value and (
         ";" in normalized_value
         or "\n" in normalized_value

--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -116,3 +116,11 @@ def test_parse_nested_json_wrappers():
     cred = parse_credential(raw, "ignored")
     assert cred.storage_account == "cnpgdemo"
     assert cred.account_key == "abcd"
+
+
+def test_parse_development_storage_connection_string():
+    raw = "UseDevelopmentStorage=true"
+    cred = parse_credential(raw, "devstoreaccount1")
+    assert cred.connection_string == "UseDevelopmentStorage=true"
+    assert cred.storage_account == "devstoreaccount1"
+    assert cred.account_key is None


### PR DESCRIPTION
## Summary
- support Azure Storage emulator connection strings in normalize_azure_storage_secret
- keep UseDevelopmentStorage connection strings intact while normalizing line endings
- cover the new scenario with a targeted unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5a9a85b40832b98b4f6dc35c60f4c