### PR TITLE
Handle simple storage keys without delimiters

### DIFF
--- a/tests/test_normalize_azure_storage_secret.py
+++ b/tests/test_normalize_azure_storage_secret.py
@@ -136,3 +136,11 @@ def test_parse_yaml_style_pairs():
     assert cred.storage_account == "cnpgdemo"
     assert cred.account_key == "abcd1234=="
     assert "BlobEndpoint=https://cnpgdemo.blob.core.windows.net/" in cred.connection_string
+
+
+def test_parse_short_account_key_without_delimiters():
+    raw = "rwsdqn2z17r0jcb"
+    cred = parse_credential(raw, "demoacct")
+    assert cred.storage_account == "demoacct"
+    assert cred.account_key == raw
+    assert f"AccountKey={raw}" in cred.connection_string


### PR DESCRIPTION
## Summary
- detect delimiter-free credential strings as Azure storage account keys
- cover the new parsing path with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d629f525d8832b96c9b0d52afde828