### PR TITLE
Fix indentation for ApplicationSet Helm values block

### DIFF
--- a/gitops/clusters/aks/apps/platform-charts.applicationset.yaml
+++ b/gitops/clusters/aks/apps/platform-charts.applicationset.yaml
@@ -54,7 +54,7 @@ spec:
         helm:
           releaseName: '{{.name}}'
           values: |
-{{ toYaml .values | indent 12 }}
+            {{- toYaml .values | nindent 12 }}
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
## Summary
- align the ApplicationSet Helm values block so the YAML parses correctly

## Testing
- `kustomize build gitops/clusters/aks` *(fails: kustomize is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d62daae718832b996faf4a0f9275b0