### PR TITLE
Ensure IAM Argo CD application uses rendered repo context

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -101,6 +101,24 @@ jobs:
           EOF
           mv "${tmp_file}" "${config_file}"
 
+      - name: Render GitOps context configuration
+        shell: bash
+        env:
+          GITOPS_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          GITOPS_TARGET_REVISION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cat <<EOF > gitops/clusters/aks/context.yaml
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: gitops-context
+            namespace: argocd
+          data:
+            repoURL: ${GITOPS_REPO_URL}
+            targetRevision: ${GITOPS_TARGET_REVISION}
+          EOF
+
       - name: Create IAM namespace early
         shell: bash
         run: |

--- a/gitops/clusters/aks/kustomization.yaml
+++ b/gitops/clusters/aks/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - context.yaml
   - projects
   - apps
+configurations:
+  - kustomizeconfig/argocd-applications.yaml
 vars:
   - name: GITOPS_REPO_URL
     objref:

--- a/gitops/clusters/aks/kustomizeconfig/argocd-applications.yaml
+++ b/gitops/clusters/aks/kustomizeconfig/argocd-applications.yaml
@@ -1,0 +1,9 @@
+varReference:
+  - kind: Application
+    path: spec/source/repoURL
+  - kind: Application
+    path: spec/source/targetRevision
+  - kind: ApplicationSet
+    path: spec/template/spec/source/repoURL
+  - kind: ApplicationSet
+    path: spec/template/spec/source/targetRevision


### PR DESCRIPTION
## Summary
- render the gitops context ConfigMap during the bootstrap workflow using the current repository metadata
- configure kustomize to substitute repo URL and revision variables within Argo CD Application resources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63e270748832ba8ce4bb585776bf1