### PR TITLE
Ensure Argo project repo placeholder is substituted

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Run the workflow **“04 - Configure demo hosts”** after the bootstrap finis
 - `scripts/check_keycloak_first_class_fields.py` guards against regressing to deprecated Keycloak CLI flags – run it whenever you edit the Keycloak CR.
 - Need to rotate ingress hosts manually? Execute `python3 scripts/configure_demo_hosts.py --ingress-ip <EXTERNAL-IP>` and commit the updated parameters file.
 
+### Debugging Argo CD repo permissions
+
+If the IAM application loops with `application repo ... is not permitted in project 'iam'`, ensure the kustomization rendered the `gitops/clusters/aks/projects/iam.yaml` manifest with your repository URL. The AppProject’s `spec.sourceRepos` is templated via `kustomizeconfig/argocd-applications.yaml`; reapply the bootstrap kustomization after updating [`context.yaml`](gitops/clusters/aks/context.yaml) so the ConfigMap and AppProject stay in sync.
+
 ## 5. Testing locally
 
 Install the lightweight toolchain and run the unit tests:

--- a/gitops/clusters/aks/kustomizeconfig/argocd-applications.yaml
+++ b/gitops/clusters/aks/kustomizeconfig/argocd-applications.yaml
@@ -1,9 +1,16 @@
 varReference:
   - kind: Application
+    group: argoproj.io
     path: spec/source/repoURL
   - kind: Application
+    group: argoproj.io
     path: spec/source/targetRevision
+  - kind: AppProject
+    group: argoproj.io
+    path: spec/sourceRepos
   - kind: ApplicationSet
+    group: argoproj.io
     path: spec/template/spec/source/repoURL
   - kind: ApplicationSet
+    group: argoproj.io
     path: spec/template/spec/source/targetRevision


### PR DESCRIPTION
## Summary
- teach the argocd kustomizeconfig to substitute the AppProject spec.sourceRepos with the rendered repo URL
- add a regression test covering the AppProject placeholder and keep documentation lean with debugging guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d668d0390c832bbcbe916f5de4da2b