### PR TITLE
Add preflight for Keycloak CRDs and improve ingress diagnostics

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -194,6 +194,23 @@ jobs:
           set -euo pipefail
           kubectl apply -k gitops/clusters/aks
 
+      - name: Verify Keycloak operator CRDs
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for crd in keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org; do
+            if ! kubectl get crd "${crd}" >/dev/null 2>&1; then
+              echo "::error::Keycloak operator CRD '${crd}' is missing. Install the operator before bootstrapping."
+              missing=1
+            fi
+          done
+          if [ "${missing}" -ne 0 ]; then
+            echo "Existing Keycloak-related CRDs:" >&2
+            kubectl get crd | grep -i keycloak || true
+            exit 1
+          fi
+
       - name: Wait for platform addons
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Trigger the workflow **“01 - Provision AKS with Terraform”** (`.github/wor
    - Normalise the Azure Blob credentials into the `cnpg-azure-backup` secret using `scripts/normalize_azure_storage_secret.py`.
    - Apply the GitOps tree (`gitops/clusters/aks`) so Argo CD manages addons (cert-manager, CloudNativePG operator, ingress-nginx) and the IAM workloads (CloudNativePG cluster, Keycloak, midPoint).
    - Wait for all applications to report `Synced` and `Healthy`.
+   - Verify that the Keycloak operator CRDs (`keycloaks.k8s.keycloak.org`, `keycloakrealmimports.k8s.keycloak.org`) are already installed in the cluster; the workflow now fails fast if they are missing so you can install the operator before retrying.
 
 ### Troubleshooting: Argo CD project denies the repo
 


### PR DESCRIPTION
## Summary
- add a preflight check in the bootstrap workflow to ensure the Keycloak operator CRDs exist before waiting on the IAM application
- enrich the configure_demo_hosts error message with service type and load balancer status when no ingress address is published
- document the Keycloak CRD requirement in the bootstrap instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6721eb114832ba557439eabb8eda8