### PR TITLE
Improve Keycloak CRD diagnostics in bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -198,16 +198,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          missing=0
+          missing_crds=()
           for crd in keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org; do
             if ! kubectl get crd "${crd}" >/dev/null 2>&1; then
-              echo "::error::Keycloak operator CRD '${crd}' is missing. Install the operator before bootstrapping."
-              missing=1
+              missing_crds+=("${crd}")
             fi
           done
-          if [ "${missing}" -ne 0 ]; then
-            echo "Existing Keycloak-related CRDs:" >&2
-            kubectl get crd | grep -i keycloak || true
+          if [ "${#missing_crds[@]}" -ne 0 ]; then
+            printf '::error::Keycloak operator CRDs missing: %s\n' "${missing_crds[*]}"
+            echo 'kubectl api-resources --api-group=k8s.keycloak.org output:'
+            kubectl api-resources --api-group=k8s.keycloak.org || true
+            echo 'Existing Keycloak-related CRDs:'
+            kubectl get crd | grep -i keycloak || echo 'none'
+            echo 'Keycloak pods currently running:'
+            kubectl get pods -A | grep -i keycloak || echo 'none'
+            echo 'Install the Keycloak operator (https://www.keycloak.org/operator/installation) and rerun the workflow.'
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- expand the Keycloak CRD verification step to report missing resources and related cluster state
- guide operators towards the official installation docs when the operator is absent

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d67ed5f71c832b938bbdf7d4fc21e5