### PR TITLE
Deploy Keycloak operator during bootstrap

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -194,27 +194,40 @@ jobs:
           set -euo pipefail
           kubectl apply -k gitops/clusters/aks
 
-      - name: Verify Keycloak operator CRDs
+      - name: Wait for Keycloak operator CRDs
         shell: bash
         run: |
           set -euo pipefail
-          missing_crds=()
-          for crd in keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org; do
-            if ! kubectl get crd "${crd}" >/dev/null 2>&1; then
-              missing_crds+=("${crd}")
+          required_crds=(keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org)
+          missing_crds=("${required_crds[@]}")
+          for attempt in $(seq 1 12); do
+            missing_crds=()
+            for crd in "${required_crds[@]}"; do
+              if ! kubectl get crd "${crd}" >/dev/null 2>&1; then
+                missing_crds+=("${crd}")
+              fi
+            done
+
+            if [ "${#missing_crds[@]}" -eq 0 ]; then
+              echo "All Keycloak operator CRDs are present."
+              exit 0
+            fi
+
+            echo "Attempt ${attempt}/12: waiting for Keycloak operator CRDs to be installed (${missing_crds[*]} still missing)..."
+            if [ "${attempt}" -lt 12 ]; then
+              sleep 10
             fi
           done
-          if [ "${#missing_crds[@]}" -ne 0 ]; then
-            printf '::error::Keycloak operator CRDs missing: %s\n' "${missing_crds[*]}"
-            echo 'kubectl api-resources --api-group=k8s.keycloak.org output:'
-            kubectl api-resources --api-group=k8s.keycloak.org || true
-            echo 'Existing Keycloak-related CRDs:'
-            kubectl get crd | grep -i keycloak || echo 'none'
-            echo 'Keycloak pods currently running:'
-            kubectl get pods -A | grep -i keycloak || echo 'none'
-            echo 'Install the Keycloak operator (https://www.keycloak.org/operator/installation) and rerun the workflow.'
-            exit 1
-          fi
+
+          printf '::error::Keycloak operator CRDs missing after wait: %s\n' "${missing_crds[*]}"
+          echo 'kubectl api-resources --api-group=k8s.keycloak.org output:'
+          kubectl api-resources --api-group=k8s.keycloak.org || true
+          echo 'Existing Keycloak-related CRDs:'
+          kubectl get crd | grep -i keycloak || echo 'none'
+          echo 'Keycloak pods currently running:'
+          kubectl get pods -A | grep -i keycloak || echo 'none'
+          echo 'Install the Keycloak operator (https://www.keycloak.org/operator/installation) and rerun the workflow.'
+          exit 1
 
       - name: Wait for platform addons
         shell: bash

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Trigger the workflow **“01 - Provision AKS with Terraform”** (`.github/wor
    - Optionally configure repository credentials when the repo is private.
    - Create the database and admin secrets in the `iam` namespace.
    - Normalise the Azure Blob credentials into the `cnpg-azure-backup` secret using `scripts/normalize_azure_storage_secret.py`.
-   - Apply the GitOps tree (`gitops/clusters/aks`) so Argo CD manages addons (cert-manager, CloudNativePG operator, ingress-nginx) and the IAM workloads (CloudNativePG cluster, Keycloak, midPoint).
+   - Apply the GitOps tree (`gitops/clusters/aks`) so Argo CD manages addons (cert-manager, CloudNativePG operator, ingress-nginx, Keycloak operator) and the IAM workloads (CloudNativePG cluster, Keycloak, midPoint).
    - Wait for all applications to report `Synced` and `Healthy`.
-   - Verify that the Keycloak operator CRDs (`keycloaks.k8s.keycloak.org`, `keycloakrealmimports.k8s.keycloak.org`) are already installed in the cluster; the workflow now fails fast if they are missing so you can install the operator before retrying.
+   - Wait for the Keycloak operator CRDs (`keycloaks.k8s.keycloak.org`, `keycloakrealmimports.k8s.keycloak.org`) to appear; the workflow now deploys the upstream manifests automatically and surfaces detailed diagnostics if the CRDs never register.
 
 ### Troubleshooting: Argo CD project denies the repo
 

--- a/gitops/clusters/aks/apps/keycloak-operator.application.yaml
+++ b/gitops/clusters/aks/apps/keycloak-operator.application.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keycloak-operator
+  namespace: argocd
+spec:
+  project: platform
+  destination:
+    namespace: keycloak
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://github.com/keycloak/keycloak-k8s-resources.git
+    targetRevision: 26.3.4
+    path: kubernetes
+    directory:
+      recurse: true
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/gitops/clusters/aks/apps/kustomization.yaml
+++ b/gitops/clusters/aks/apps/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - platform-charts.applicationset.yaml
+  - keycloak-operator.application.yaml
   - iam.application.yaml
 configurations:
   - kustomizeconfig.yaml

--- a/gitops/clusters/aks/projects/platform.yaml
+++ b/gitops/clusters/aks/projects/platform.yaml
@@ -10,6 +10,7 @@ spec:
     - https://charts.jetstack.io
     - https://cloudnative-pg.github.io/charts
     - https://kubernetes.github.io/ingress-nginx
+    - https://github.com/keycloak/keycloak-k8s-resources.git
   destinations:
     - namespace: '*'
       server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary
- add an Argo CD application that deploys the upstream Keycloak operator and allow the repo in the platform project
- wait for the Keycloak CRDs during the bootstrap workflow with retries and improved diagnostics
- document the automation change in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6a5876214832b951d19981af04e2b