### PR TITLE
Update Keycloak health probe evaluation

### DIFF
--- a/gitops/clusters/aks/bootstrap/argocd-cm-patch.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-cm-patch.yaml
@@ -12,6 +12,47 @@ data:
   resource.customizations.health.k8s.keycloak.org_Keycloak: |
     hs = {}
     if obj.status ~= nil then
+      if obj.status.conditions ~= nil then
+        for _, condition in ipairs(obj.status.conditions) do
+          if condition.type == "Ready" then
+            if condition.status == "True" then
+              hs.status = "Healthy"
+              if condition.message ~= nil and condition.message ~= "" then
+                hs.message = condition.message
+              else
+                hs.message = "Keycloak reports ready"
+              end
+              return hs
+            end
+            if condition.status == "False" then
+              if condition.reason ~= nil then
+                local reason = string.lower(condition.reason)
+                if string.find(reason, "error") ~= nil or string.find(reason, "fail") ~= nil then
+                  hs.status = "Degraded"
+                  if condition.message ~= nil and condition.message ~= "" then
+                    hs.message = condition.message
+                  else
+                    hs.message = condition.reason
+                  end
+                  return hs
+                end
+              end
+              if condition.message ~= nil and condition.message ~= "" then
+                hs.message = condition.message
+              end
+            end
+          end
+          if condition.type == "HasErrors" and condition.status == "True" then
+            hs.status = "Degraded"
+            if condition.message ~= nil and condition.message ~= "" then
+              hs.message = condition.message
+            else
+              hs.message = "Keycloak reports errors"
+            end
+            return hs
+          end
+        end
+      end
       if obj.status.ready == true or obj.status.phase == "Ready" then
         hs.status = "Healthy"
         hs.message = "Keycloak reports ready"


### PR DESCRIPTION
## Summary
- extend the Argo CD Keycloak health customization to read the operator's Ready condition
- mark the application degraded when the operator reports explicit errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ae3dcc70832bb7ba6db6f3eac47c