### PR TITLE
Add Keycloak database manifest to CNPG stack

### DIFF
--- a/gitops/apps/iam/cnpg/database-keycloak.yaml
+++ b/gitops/apps/iam/cnpg/database-keycloak.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: keycloak
+  namespace: iam
+spec:
+  cluster:
+    name: iam-db
+  name: keycloak
+  owner: keycloak
+  schemas:
+    - name: public
+      owner: keycloak

--- a/gitops/apps/iam/cnpg/kustomization.yaml
+++ b/gitops/apps/iam/cnpg/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster.yaml
+  - database-keycloak.yaml
   - database-midpoint.yaml
 configurations:
   - kustomizeconfig.yaml


### PR DESCRIPTION
## Summary
- add a CloudNativePG Database manifest for the Keycloak schema and wire it into the iam CNPG kustomization to ensure the database is provisioned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b4c2134c832b93b03ddc0826bbe3