### PR TITLE
Add default IAM secrets for demo workloads

### DIFF
--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - secrets
   - cnpg
   - keycloak
   - midpoint

--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: iam
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+  - name: keycloak-db-app
+    literals:
+      - username=keycloak
+      - password=keycloak123!
+  - name: midpoint-db-app
+    literals:
+      - username=midpoint
+      - password=midpoint123!
+  - name: midpoint-admin
+    literals:
+      - username=administrator
+      - password=admin123!


### PR DESCRIPTION
## Summary
- generate static demo secrets for Keycloak and MidPoint database and admin credentials
- include the secrets package in the IAM kustomization so Argo CD applies them before workloads start

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c0083af8832bb208d3a584db58a0