### PR TITLE
Configure Keycloak health probes and improve Argo health messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Run the workflow **“04 - Configure demo hosts”** after the bootstrap finis
 
 - The GitOps tree lives under `gitops/`. Update manifests, commit, and let Argo CD reconcile the cluster. `kubectl apply` is only needed for the initial bootstrap.
 - `scripts/check_keycloak_first_class_fields.py` guards against regressing to deprecated Keycloak CLI flags – run it whenever you edit the Keycloak CR.
+- Keycloak's probes are wired to the operator-managed management port (9000) and call the documented `/health/ready` and `/health/live` endpoints. When Argo CD reports the Keycloak resource as `Degraded` with a health-related reason, inspect those endpoints via `kubectl port-forward` to confirm whether the instance is reporting that it is not ready or not alive yet.
 - Need to rotate ingress hosts manually? Execute `python3 scripts/configure_demo_hosts.py --ingress-ip <EXTERNAL-IP>` and commit the updated parameters file.
 
 ### Debugging Argo CD repo permissions

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -50,5 +50,23 @@ spec:
       cpu: "1"
       memory: "2Gi"
   startupProbe:
+    httpGet:
+      path: /health/ready
+      port: 9000
+      scheme: HTTP
     periodSeconds: 5
     failureThreshold: 12
+  readinessProbe:
+    httpGet:
+      path: /health/ready
+      port: 9000
+      scheme: HTTP
+    periodSeconds: 5
+    failureThreshold: 6
+  livenessProbe:
+    httpGet:
+      path: /health/live
+      port: 9000
+      scheme: HTTP
+    periodSeconds: 10
+    failureThreshold: 3

--- a/gitops/clusters/aks/bootstrap/argocd-cm-patch.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-cm-patch.yaml
@@ -25,9 +25,10 @@ data:
               return hs
             end
             if condition.status == "False" then
+              local lower_reason = nil
               if condition.reason ~= nil then
-                local reason = string.lower(condition.reason)
-                if string.find(reason, "error") ~= nil or string.find(reason, "fail") ~= nil then
+                lower_reason = string.lower(condition.reason)
+                if string.find(lower_reason, "error") ~= nil or string.find(lower_reason, "fail") ~= nil then
                   hs.status = "Degraded"
                   if condition.message ~= nil and condition.message ~= "" then
                     hs.message = condition.message
@@ -36,6 +37,15 @@ data:
                   end
                   return hs
                 end
+              end
+              if lower_reason ~= nil and string.find(lower_reason, "health") ~= nil then
+                hs.status = "Degraded"
+                if condition.message ~= nil and condition.message ~= "" then
+                  hs.message = condition.message
+                else
+                  hs.message = "Keycloak health endpoint reports not ready"
+                end
+                return hs
               end
               if condition.message ~= nil and condition.message ~= "" then
                 hs.message = condition.message


### PR DESCRIPTION
## Summary
- point Keycloak startup, readiness, and liveness probes at the documented management health endpoints
- surface health-related Ready condition failures in Argo CD with a clearer message
- document how to inspect the Keycloak /health endpoints when Argo CD reports degradation

## Testing
- python scripts/check_keycloak_first_class_fields.py
- pytest tests/test_gitops_structure.py *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68d6d87eb06c832b8589e2b33770ecdd