### PR TITLE
Align IAM secret generators with basic-auth type

### DIFF
--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -7,14 +7,17 @@ generatorOptions:
 
 secretGenerator:
   - name: keycloak-db-app
+    type: kubernetes.io/basic-auth
     literals:
       - username=keycloak
       - password=keycloak123!
   - name: midpoint-db-app
+    type: kubernetes.io/basic-auth
     literals:
       - username=midpoint
       - password=midpoint123!
   - name: midpoint-admin
+    type: kubernetes.io/basic-auth
     literals:
       - username=administrator
       - password=admin123!


### PR DESCRIPTION
## Summary
- set IAM secret generators to use the kubernetes.io/basic-auth type so Argo CD no longer attempts to mutate immutable secret types

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e06e0c58832b9206985c4c82ebdc