### PR TITLE
Fix secret types to avoid immutable field errors

### DIFF
--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -7,17 +7,17 @@ generatorOptions:
 
 secretGenerator:
   - name: keycloak-db-app
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=keycloak
       - password=keycloak123!
   - name: midpoint-db-app
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=midpoint
       - password=midpoint123!
   - name: midpoint-admin
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=administrator
       - password=admin123!


### PR DESCRIPTION
## Summary
- align IAM database and admin secrets to use the immutable Opaque type
- prevent client-side apply migrations from failing due to type changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6f18a6974832bb28a2797ae686164