### PR TITLE
Fix secret generator types for IAM secrets

### DIFF
--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -7,17 +7,17 @@ generatorOptions:
 
 secretGenerator:
   - name: keycloak-db-app
-    type: Opaque
+    type: kubernetes.io/basic-auth
     literals:
       - username=keycloak
       - password=keycloak123!
   - name: midpoint-db-app
-    type: Opaque
+    type: kubernetes.io/basic-auth
     literals:
       - username=midpoint
       - password=midpoint123!
   - name: midpoint-admin
-    type: Opaque
+    type: kubernetes.io/basic-auth
     literals:
       - username=administrator
       - password=admin123!


### PR DESCRIPTION
## Summary
- align the generated IAM secrets with the kubernetes.io/basic-auth type expected by existing resources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f68f3980832bbfc249a7731a9ae4