### PR TITLE
Force IAM secrets to be replaced during sync

### DIFF
--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: iam
 
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 
 secretGenerator:
   - name: keycloak-db-app


### PR DESCRIPTION
## Summary
- ensure the generated IAM secrets carry the Argo CD Replace sync option so the type can be updated cleanly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6fbf2c218832b86e363bfa4718605