### PR TITLE
Align secret generator types with existing resources

### DIFF
--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -7,17 +7,17 @@ generatorOptions:
 
 secretGenerator:
   - name: keycloak-db-app
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=keycloak
       - password=keycloak123!
   - name: midpoint-db-app
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=midpoint
       - password=midpoint123!
   - name: midpoint-admin
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=administrator
       - password=admin123!


### PR DESCRIPTION
## Summary
- align Kustomize secret generators with the immutable Opaque type used by existing cluster secrets
- prevent client-side apply from attempting to mutate the secret type during reconciliation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6fbf2c218832b86e363bfa4718605