### PR TITLE
Run GitOps validations before bootstrap and rotate secrets

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -32,6 +32,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-dev.txt
+
+      - name: Run GitOps validation tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          pytest -q
+
       - name: Azure Login (OIDC)
         uses: azure/login@v2
         with:
@@ -138,18 +151,21 @@ jobs:
             echo "Database credentials are required (POSTGRES_SUPERUSER_PASSWORD, KEYCLOAK_DB_PASSWORD, MIDPOINT_DB_PASSWORD)."
             exit 1
           fi
+          for secret in cnpg-superuser keycloak-db-app midpoint-db-app; do
+            kubectl -n "${NAMESPACE_IAM}" delete secret "${secret}" --ignore-not-found >/dev/null 2>&1 || true
+          done
           kubectl -n "${NAMESPACE_IAM}" create secret generic cnpg-superuser \
-            --type=kubernetes.io/basic-auth \
+            --type=Opaque \
             --from-literal=username=postgres \
             --from-literal=password="${POSTGRES_SUPERUSER_PASSWORD}" \
             --dry-run=client -o yaml | kubectl apply -f -
           kubectl -n "${NAMESPACE_IAM}" create secret generic keycloak-db-app \
-            --type=kubernetes.io/basic-auth \
+            --type=Opaque \
             --from-literal=username=keycloak \
             --from-literal=password="${KEYCLOAK_DB_PASSWORD}" \
             --dry-run=client -o yaml | kubectl apply -f -
           kubectl -n "${NAMESPACE_IAM}" create secret generic midpoint-db-app \
-            --type=kubernetes.io/basic-auth \
+            --type=Opaque \
             --from-literal=username=midpoint \
             --from-literal=password="${MIDPOINT_DB_PASSWORD}" \
             --dry-run=client -o yaml | kubectl apply -f -
@@ -165,8 +181,9 @@ jobs:
             echo "MIDPOINT_ADMIN_PASSWORD secret is required."
             exit 1
           fi
+          kubectl -n "${NAMESPACE_IAM}" delete secret midpoint-admin --ignore-not-found >/dev/null 2>&1 || true
           kubectl -n "${NAMESPACE_IAM}" create secret generic midpoint-admin \
-            --type=kubernetes.io/basic-auth \
+            --type=Opaque \
             --from-literal=username=administrator \
             --from-literal=password="${MIDPOINT_ADMIN_PASSWORD}" \
             --dry-run=client -o yaml | kubectl apply -f -

--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -9,17 +9,17 @@ generatorOptions:
 
 secretGenerator:
   - name: keycloak-db-app
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=keycloak
       - password=keycloak123!
   - name: midpoint-db-app
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=midpoint
       - password=midpoint123!
   - name: midpoint-admin
-    type: kubernetes.io/basic-auth
+    type: Opaque
     literals:
       - username=administrator
       - password=admin123!

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -87,11 +87,11 @@ def test_params_env_defaults():
     assert "midpointHost=" in params
 
 
-def test_iam_secret_generators_use_basic_auth_type():
+def test_iam_secret_generators_use_opaque_type():
     kustomization = yaml.safe_load(
         (REPO_ROOT / "gitops/apps/iam/secrets/kustomization.yaml").read_text(encoding="utf-8")
     )
     secrets = kustomization.get("secretGenerator", [])
     assert secrets, "secretGenerator entries should be defined for IAM secrets"
     for secret in secrets:
-        assert secret.get("type") == "kubernetes.io/basic-auth"
+        assert secret.get("type") == "Opaque"


### PR DESCRIPTION
## Summary
- run the repository's validation tests before the GitOps bootstrap interacts with the cluster
- delete stale IAM secrets during bootstrap and recreate them as Opaque secrets to avoid type drift
- document the new workflow behaviour and update manifest tests for the Opaque secret type

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7937025c0832bb1bb8cb8c80d8b3b