### PR TITLE
Fix Keycloak additional options syntax

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -8,12 +8,9 @@ spec:
   instances: 1
   startOptimized: false
   additionalOptions:
-    - name: health-enabled
-      value: "true"
-    - name: metrics-enabled
-      value: "true"
-    - name: hostname-strict-https
-      value: "false"
+    - "--health-enabled=true"
+    - "--metrics-enabled=true"
+    - "--hostname-strict-https=false"
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- use the Keycloak operator's expected string form for additionalOptions to avoid schema mismatches

## Testing
- pytest tests/test_gitops_structure.py

------
https://chatgpt.com/codex/tasks/task_e_68d7972756ec832bb0363cbc4d70f272