### PR TITLE
Fix Keycloak additional options schema

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -8,9 +8,12 @@ spec:
   instances: 1
   startOptimized: false
   additionalOptions:
-    - "--health-enabled=true"
-    - "--metrics-enabled=true"
-    - "--hostname-strict-https=false"
+    - name: health-enabled
+      value: "true"
+    - name: metrics-enabled
+      value: "true"
+    - name: hostname-strict-https
+      value: "false"
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- represent Keycloak additionalOptions entries as name/value pairs to satisfy the v2alpha1 schema requirements

## Testing
- scripts/check_keycloak_first_class_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68d79e5bb178832b86966a4389f26067