### PR TITLE
Treat Keycloak Running phase as healthy

### DIFF
--- a/gitops/clusters/aks/bootstrap/argocd-cm-patch.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-cm-patch.yaml
@@ -63,7 +63,11 @@ data:
           end
         end
       end
-      if obj.status.ready == true or obj.status.phase == "Ready" then
+      if
+        obj.status.ready == true
+        or obj.status.phase == "Ready"
+        or obj.status.phase == "Running"
+      then
         hs.status = "Healthy"
         hs.message = "Keycloak reports ready"
         return hs


### PR DESCRIPTION
## Summary
- update the Argo CD health check so Keycloak CRs in the Running phase are considered healthy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a23fa088832ba678ef240f439daf