### PR TITLE
Remove deprecated Keycloak HTTPS flag

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -12,8 +12,6 @@ spec:
       value: "true"
     - name: metrics-enabled
       value: "true"
-    - name: hostname-strict-https
-      value: "false"
   features:
     enabled:
       - token-exchange

--- a/scripts/check_keycloak_first_class_fields.py
+++ b/scripts/check_keycloak_first_class_fields.py
@@ -12,6 +12,7 @@ MANIFEST = REPO_ROOT / "gitops/apps/iam/keycloak/keycloak.yaml"
 BANNED_ADDITIONAL_OPTIONS = {
     re.compile(r"^\s*-?\s*name:\s*db-url\s*$", re.MULTILINE): "--db-url",
     re.compile(r"^\s*-?\s*name:\s*hostname-strict\s*$", re.MULTILINE): "--hostname-strict",
+    re.compile(r"^\s*-?\s*name:\s*hostname-strict-https\s*$", re.MULTILINE): "--hostname-strict-https",
     re.compile(r"^\s*-?\s*name:\s*features\s*$", re.MULTILINE): "--features",
 }
 


### PR DESCRIPTION
## Summary
- drop the deprecated `hostname-strict-https` additional option from the Keycloak CR so the operator no longer passes a removed flag to Keycloak
- extend `check_keycloak_first_class_fields.py` to block reintroducing the removed flag alongside other banned options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a23fa088832ba678ef240f439daf