### PR TITLE
Bump Keycloak operator and runtime to 26.3.5

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rws-keycloak
   namespace: iam
 spec:
-  image: quay.io/keycloak/keycloak:26.3.4
+  image: quay.io/keycloak/keycloak:26.3.5
   instances: 1
   startOptimized: false
   additionalOptions:

--- a/gitops/clusters/aks/apps/keycloak-operator.application.yaml
+++ b/gitops/clusters/aks/apps/keycloak-operator.application.yaml
@@ -10,7 +10,7 @@ spec:
     server: https://kubernetes.default.svc
   source:
     repoURL: https://github.com/keycloak/keycloak-k8s-resources.git
-    targetRevision: 26.3.4
+    targetRevision: 26.3.5
     path: kubernetes
     directory:
       recurse: true


### PR DESCRIPTION
## Summary
- bump the Keycloak deployment image to version 26.3.5
- update the Keycloak operator application to track tag 26.3.5

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a93f16b8832bbaa6d76d19ebbd5f