### PR TITLE
Set Keycloak ingress hostname

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -36,6 +36,7 @@ spec:
   ingress:
     enabled: true
     className: nginx
+    hostname: kc.127.0.0.1.nip.io
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -42,6 +42,7 @@ replacements:
           name: rws-keycloak
         fieldPaths:
           - spec.hostname.hostname
+          - spec.ingress.hostname
   - source:
       kind: ConfigMap
       name: iam-ingress-settings


### PR DESCRIPTION
## Summary
- add an explicit hostname to the Keycloak ingress configuration
- extend the shared replacement so the Keycloak ingress host follows the params configmap

## Testing
- python scripts/check_keycloak_first_class_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68d7abd5ae44832b905b521e226b5596