### PR TITLE
Document IAM sync timeout diagnostics and gate IAM on operator CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ If the `iam` application reports `application repo … is not permitted in proje
 
 Argo CD 2.11 migrates existing resources to client-side apply, which surfaces immutable field errors if the live object was created with a different schema than the GitOps source. The bootstrap workflow now seeds the IAM database and admin credentials as [`Opaque` secrets](.github/workflows/02_bootstrap_argocd.yml) and proactively deletes any older basic-auth secrets before recreating them. If the application remains `Degraded` with a message similar to `Secret "keycloak-db-app" is invalid: type: Invalid value: "kubernetes.io/basic-auth": field is immutable`, delete the affected secret (Argo will recreate it on the next sync) so the type converges on the new schema.
 
+### Troubleshooting: IAM sync timeout waiting for Keycloak CRDs
+
+When the IAM application reports `one or more synchronization tasks are not valid due to application controller sync timeout`, Argo CD is trying to apply Keycloak custom resources before the operator finishes installing its CRDs. Longer timeouts do not help because the resources remain invalid until the CRDs appear. Follow the runbook in [`docs/troubleshooting/iam-sync-timeout.md`](docs/troubleshooting/iam-sync-timeout.md) to gather the relevant controller state and apply the sync-wave fix so the Keycloak operator finishes before the IAM stack reconciles.
+
 ## 3. Publish demo ingress hostnames
 
 Run the workflow **“04 - Configure demo hosts”** after the bootstrap finishes. The job calls [`scripts/configure_demo_hosts.py`](scripts/configure_demo_hosts.py) to discover the ingress IP, updates [`gitops/apps/iam/params.env`](gitops/apps/iam/params.env) with fresh `nip.io` hostnames, commits the change and prints the URLs.

--- a/docs/troubleshooting/iam-sync-timeout.md
+++ b/docs/troubleshooting/iam-sync-timeout.md
@@ -1,0 +1,63 @@
+# IAM application sync timeout runbook
+
+## Symptoms
+
+* Argo CD shows the `iam` application as `sync=OutOfSync`, `health=Degraded`, `phase=Running`.
+* The Argo CD UI or `argocd app get iam` reports the last operation message similar to:
+  `one or more synchronization tasks are not valid due to application controller sync timeout`.
+* Repeated retries do not make progress (`Retrying attempt #<n>`), even after increasing the sync timeout.
+
+## Why longer timeouts do not help
+
+The controller marks a sync operation as *invalid* when it tries to apply resources whose CustomResourceDefinitions (CRDs)
+are still missing. The controller retries while waiting for the CRDs to appear, but once the retry window expires it
+aborts the sync. Because the CRDs never became available, giving the controller more time only produces longer stalls.
+
+In the IAM stack this happens when the `iam` application starts syncing before the Keycloak operator finishes installing
+its CRDs. The controller cannot create `Keycloak` or `KeycloakRealmImport` resources without those CRDs, so it continually
+retries and eventually times out.
+
+## Collect the right evidence
+
+1. Confirm the status and last operation details:
+   ```bash
+   argocd app get iam
+   ```
+2. Inspect the recorded operation state and invalid tasks:
+   ```bash
+   kubectl get application iam -n argocd -o json \
+     | jq '.status.operationState | {phase, message, syncResult: .syncResult.resources[]? | select(.status == "OutOfSync")}'
+   ```
+3. Check whether the Keycloak operator application has finished reconciling:
+   ```bash
+   argocd app wait keycloak-operator --health --timeout 180
+   ```
+4. Make sure the Keycloak CRDs actually exist in the cluster:
+   ```bash
+   kubectl get crd keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org
+   ```
+5. If the CRDs are missing, inspect the operator controller logs for installation errors:
+   ```bash
+   kubectl logs deployment/keycloak-operator -n keycloak --since=15m
+   ```
+
+Collecting this data before attempting a fix ensures we know whether the failure is caused by missing CRDs or by a different
+error inside the operator.
+
+## Proposed fix – Attempt 1
+
+**Goal:** ensure the Keycloak operator (and its CRDs) are installed before Argo CD attempts to sync the IAM application.
+
+**Change:** add Argo CD sync waves so that the parent app-of-apps applies the `keycloak-operator` application before the
+`iam` application. Once the operator completes, the CRDs are available and the IAM sync can proceed.
+
+**Implementation steps:**
+
+1. Annotate `gitops/clusters/aks/apps/keycloak-operator.application.yaml` with `argocd.argoproj.io/sync-wave: "10"`.
+2. Annotate `gitops/clusters/aks/apps/iam.application.yaml` with `argocd.argoproj.io/sync-wave: "30"`.
+3. Commit the change and allow Argo CD to resync the parent application. The new ordering ensures the IAM application waits
+   for the operator to finish creating its CRDs before reconciling Keycloak custom resources.
+
+If the IAM application still fails after the sync-wave change, revisit the evidence above—specifically the operator logs and
+the presence of CRDs—to determine whether the operator itself failed to install or if a different dependency (for example the
+CloudNativePG operator) is missing. Document those findings before attempting a second fix.

--- a/gitops/clusters/aks/apps/iam.application.yaml
+++ b/gitops/clusters/aks/apps/iam.application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: iam
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
 spec:
   project: iam
   destination:

--- a/gitops/clusters/aks/apps/keycloak-operator.application.yaml
+++ b/gitops/clusters/aks/apps/keycloak-operator.application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: keycloak-operator
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   project: platform
   destination:


### PR DESCRIPTION
## Summary
- document how to troubleshoot the IAM application's sync timeout and collect the right Argo CD evidence
- note the new runbook in the main README
- ensure the keycloak-operator application syncs before IAM by adding explicit sync waves

## Testing
- not run (documentation and manifest ordering change)


------
https://chatgpt.com/codex/tasks/task_e_68d7afe71bbc832b991bcbeb724a8371