### PR TITLE
Document IAM sync timeout runbook and add diagnostics script

### DIFF
--- a/docs/troubleshooting/iam-sync-timeout.md
+++ b/docs/troubleshooting/iam-sync-timeout.md
@@ -19,6 +19,11 @@ retries and eventually times out.
 
 ## Collect the right evidence
 
+Run `scripts/collect_keycloak_diagnostics.sh` to capture the key Argo CD and Kubernetes state when the timeout occurs. The script
+gathers the IAM and Keycloak operator application status, the operation state that lists invalid tasks, the presence of the
+Keycloak CRDs, and recent operator logs so you can attach them to an incident or support ticket. If you prefer to run the
+commands manually, follow the steps below.
+
 1. Confirm the status and last operation details:
    ```bash
    argocd app get iam

--- a/scripts/collect_keycloak_diagnostics.sh
+++ b/scripts/collect_keycloak_diagnostics.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+error() {
+  echo "[error] $*" >&2
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    error "Required command '$cmd' not found in PATH"
+    exit 1
+  fi
+}
+
+section() {
+  local title="$1"
+  printf '\n===== %s =====\n' "$title"
+}
+
+run_cmd() {
+  local description="$1"
+  shift
+
+  section "$description"
+  if "$@"; then
+    return 0
+  fi
+
+  local status=$?
+  error "Command failed with status $status: $*"
+  return 0
+}
+
+require_cmd kubectl
+require_cmd jq
+
+if command -v argocd >/dev/null 2>&1; then
+  run_cmd "Argo CD application summary (iam)" \
+    argocd app get iam
+
+  run_cmd "Argo CD application summary (keycloak-operator)" \
+    argocd app get keycloak-operator
+
+  run_cmd "Argo CD operation state (iam)" bash -c \
+    "kubectl get application iam -n argocd -o json \
+      | jq '.status.operationState | {phase, message, syncResult: .syncResult.resources[]? | select(.status == \"OutOfSync\")}'"
+else
+  error "'argocd' CLI not found; skipping Argo CD application summaries"
+  run_cmd "Argo CD operation state (iam)" bash -c \
+    "kubectl get application iam -n argocd -o json \
+      | jq '.status.operationState | {phase, message, syncResult: .syncResult.resources[]? | select(.status == \"OutOfSync\")}'"
+fi
+
+run_cmd "Check for Keycloak CRDs" \
+  kubectl get crd keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org
+
+run_cmd "Keycloak operator logs (last 15m)" \
+  kubectl logs deployment/keycloak-operator -n keycloak --since=15m


### PR DESCRIPTION
## Summary
- add a troubleshooting script that gathers Argo CD, CRD, and Keycloak operator diagnostics for IAM sync timeouts
- update the IAM sync timeout runbook to reference the diagnostics script and reinforce the evidence to capture before fixes

## Testing
- not run (documentation and scripting change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7c3dcad28832b97e30ef50a8f3151