### PR TITLE
Adjust midpoint readiness probe for reliable starts

### DIFF
--- a/gitops/apps/iam/midpoint/deployment.yaml
+++ b/gitops/apps/iam/midpoint/deployment.yaml
@@ -499,11 +499,16 @@ spec:
             - name: http
               containerPort: 8080
           readinessProbe:
-            httpGet:
-              path: /midpoint/login
+            # The midPoint UI login endpoint can take longer than the probe timeout to
+            # answer while the application finishes bootstrapping, which was causing
+            # repeated readiness probe timeouts.  A TCP socket check is sufficient for
+            # determining that the embedded web server is accepting requests, while the
+            # higher initial delay gives midPoint enough time to finish its start-up
+            # tasks on cold boots.
+            tcpSocket:
               port: http
-            failureThreshold: 12
-            initialDelaySeconds: 60
+            failureThreshold: 6
+            initialDelaySeconds: 120
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5


### PR DESCRIPTION
## Summary
- replace the HTTP readiness probe with a TCP socket check so that midPoint is marked ready when its web server is accepting connections
- extend the readiness initial delay to give midPoint more time to complete long cold starts and document the reasoning inline

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7d68b94a8832bb27c99a977fe30b8