### PR TITLE
Add ingress automation for Argo CD and extend host configuration

### DIFF
--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -4,3 +4,4 @@
 ingressClass=nginx
 keycloakHost=kc.20.61.182.128.nip.io
 midpointHost=mp.20.61.182.128.nip.io
+argocdHost=argocd.20.61.182.128.nip.io

--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: argocd.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  name: https

--- a/gitops/clusters/aks/bootstrap/kustomization.yaml
+++ b/gitops/clusters/aks/bootstrap/kustomization.yaml
@@ -4,5 +4,34 @@ namespace: argocd
 resources:
   - namespace.yaml
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.1.7/manifests/install.yaml
+  - argocd-ingress.yaml
 patches:
   - path: argocd-cm-patch.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: argocd-ingress-settings
+    namespace: argocd
+    envs:
+      - ../../apps/iam/params.env
+replacements:
+  - source:
+      kind: ConfigMap
+      name: argocd-ingress-settings
+      fieldPath: data.ingressClass
+    targets:
+      - select:
+          kind: Ingress
+          name: argocd-server
+        fieldPaths:
+          - spec.ingressClassName
+  - source:
+      kind: ConfigMap
+      name: argocd-ingress-settings
+      fieldPath: data.argocdHost
+    targets:
+      - select:
+          kind: Ingress
+          name: argocd-server
+        fieldPaths:
+          - spec.rules.0.host

--- a/tests/test_configure_demo_hosts.py
+++ b/tests/test_configure_demo_hosts.py
@@ -10,6 +10,7 @@ def test_build_hosts_roundtrip():
     hosts = cd.build_hosts("10.0.0.1")
     assert hosts.keycloak == "kc.10.0.0.1.nip.io"
     assert hosts.midpoint == "mp.10.0.0.1.nip.io"
+    assert hosts.argocd == "argocd.10.0.0.1.nip.io"
 
 
 def test_write_and_read_params(tmp_path: Path):
@@ -20,6 +21,7 @@ def test_write_and_read_params(tmp_path: Path):
     text = params.read_text(encoding="utf-8")
     assert "ingressClass=custom" in text
     assert "keycloakHost=kc.192.168.0.42.nip.io" in text
+    assert "argocdHost=argocd.192.168.0.42.nip.io" in text
     assert cd.read_ingress_class(params) == "custom"
 
 
@@ -48,8 +50,13 @@ def test_main_updates_env_files(monkeypatch, tmp_path: Path):
 
     saved = params.read_text(encoding="utf-8")
     assert "keycloakHost=kc.203.0.113.10.nip.io" in saved
-    assert env_file.read_text(encoding="utf-8").strip().endswith("MP_HOST=mp.203.0.113.10.nip.io")
-    assert "midpoint_url=http://mp.203.0.113.10.nip.io/midpoint" in out_file.read_text(encoding="utf-8")
+    env_contents = env_file.read_text(encoding="utf-8")
+    assert env_contents.strip().endswith("ARGOCD_HOST=argocd.203.0.113.10.nip.io")
+    assert "MP_HOST=mp.203.0.113.10.nip.io" in env_contents
+
+    output_contents = out_file.read_text(encoding="utf-8")
+    assert "midpoint_url=http://mp.203.0.113.10.nip.io/midpoint" in output_contents
+    assert "argocd_url=https://argocd.203.0.113.10.nip.io" in output_contents
 
 
 def test_resolve_ingress_ip_explicit():

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -85,6 +85,7 @@ def test_params_env_defaults():
     assert "ingressClass=" in params
     assert "keycloakHost=" in params
     assert "midpointHost=" in params
+    assert "argocdHost=" in params
 
 
 def test_iam_secret_generators_use_opaque_type():


### PR DESCRIPTION
## Summary
- add an Argo CD ingress manifest and wire it into the bootstrap kustomization with shared ingress settings
- extend the demo host configuration script to manage an Argo CD host entry alongside midpoint and keycloak
- update parameters and tests to cover the new host configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7c7c20b40832ba022d7b6abe57682