### PR TITLE
Add Argo CD ingress and extend host automation

### DIFF
--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -4,3 +4,4 @@
 ingressClass=nginx
 keycloakHost=kc.20.61.182.128.nip.io
 midpointHost=mp.20.61.182.128.nip.io
+argocdHost=argocd.20.61.182.128.nip.io

--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd
+  namespace: argocd
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: argocd.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  name: http

--- a/gitops/clusters/aks/bootstrap/kustomization.yaml
+++ b/gitops/clusters/aks/bootstrap/kustomization.yaml
@@ -4,5 +4,37 @@ namespace: argocd
 resources:
   - namespace.yaml
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.1.7/manifests/install.yaml
+  - argocd-ingress.yaml
 patches:
   - path: argocd-cm-patch.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: argocd-ingress-settings
+    namespace: argocd
+    envs:
+      - ../../../apps/iam/params.env
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: argocd-ingress-settings
+      fieldPath: data.ingressClass
+    targets:
+      - select:
+          kind: Ingress
+          name: argocd
+        fieldPaths:
+          - spec.ingressClassName
+  - source:
+      kind: ConfigMap
+      name: argocd-ingress-settings
+      fieldPath: data.argocdHost
+    targets:
+      - select:
+          kind: Ingress
+          name: argocd
+        fieldPaths:
+          - spec.rules.0.host

--- a/scripts/configure_demo_hosts.py
+++ b/scripts/configure_demo_hosts.py
@@ -19,6 +19,7 @@ DEFAULT_SERVICE = "ingress-nginx/ingress-nginx-controller"
 class Hosts:
     keycloak: str
     midpoint: str
+    argocd: str
 
 
 class KubectlError(RuntimeError):
@@ -108,7 +109,11 @@ def resolve_ingress_ip(service: str, explicit_ip: Optional[str], explicit_hostna
 def build_hosts(ip: str) -> Hosts:
     """Return nip.io hosts for the provided IP address."""
     ipaddress.ip_address(ip)
-    return Hosts(keycloak=f"kc.{ip}.nip.io", midpoint=f"mp.{ip}.nip.io")
+    return Hosts(
+        keycloak=f"kc.{ip}.nip.io",
+        midpoint=f"mp.{ip}.nip.io",
+        argocd=f"argocd.{ip}.nip.io",
+    )
 
 
 def read_ingress_class(params_file: Path) -> Optional[str]:
@@ -131,6 +136,7 @@ def write_params(params_file: Path, ingress_class: str, hosts: Hosts) -> None:
                 f"ingressClass={ingress_class}",
                 f"keycloakHost={hosts.keycloak}",
                 f"midpointHost={hosts.midpoint}",
+                f"argocdHost={hosts.argocd}",
             ]
         )
         + "\n",
@@ -172,6 +178,7 @@ def main() -> int:
     if args.print_only:
         print(hosts.keycloak)
         print(hosts.midpoint)
+        print(hosts.argocd)
         return 0
 
     write_params(args.params_file, ingress_class, hosts)
@@ -182,12 +189,14 @@ def main() -> int:
             env_file.write(f"EXTERNAL_IP={ip_value}\n")
             env_file.write(f"KC_HOST={hosts.keycloak}\n")
             env_file.write(f"MP_HOST={hosts.midpoint}\n")
+            env_file.write(f"ARGO_HOST={hosts.argocd}\n")
 
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a", encoding="utf-8") as output_file:
             output_file.write(f"keycloak_url=http://{hosts.keycloak}\n")
             output_file.write(f"midpoint_url=http://{hosts.midpoint}/midpoint\n")
+            output_file.write(f"argocd_url=http://{hosts.argocd}\n")
 
     return 0
 

--- a/tests/test_configure_demo_hosts.py
+++ b/tests/test_configure_demo_hosts.py
@@ -10,6 +10,7 @@ def test_build_hosts_roundtrip():
     hosts = cd.build_hosts("10.0.0.1")
     assert hosts.keycloak == "kc.10.0.0.1.nip.io"
     assert hosts.midpoint == "mp.10.0.0.1.nip.io"
+    assert hosts.argocd == "argocd.10.0.0.1.nip.io"
 
 
 def test_write_and_read_params(tmp_path: Path):
@@ -20,6 +21,7 @@ def test_write_and_read_params(tmp_path: Path):
     text = params.read_text(encoding="utf-8")
     assert "ingressClass=custom" in text
     assert "keycloakHost=kc.192.168.0.42.nip.io" in text
+    assert "argocdHost=argocd.192.168.0.42.nip.io" in text
     assert cd.read_ingress_class(params) == "custom"
 
 
@@ -48,8 +50,15 @@ def test_main_updates_env_files(monkeypatch, tmp_path: Path):
 
     saved = params.read_text(encoding="utf-8")
     assert "keycloakHost=kc.203.0.113.10.nip.io" in saved
-    assert env_file.read_text(encoding="utf-8").strip().endswith("MP_HOST=mp.203.0.113.10.nip.io")
-    assert "midpoint_url=http://mp.203.0.113.10.nip.io/midpoint" in out_file.read_text(encoding="utf-8")
+    env_contents = env_file.read_text(encoding="utf-8")
+    assert "KC_HOST=kc.203.0.113.10.nip.io" in env_contents
+    assert "MP_HOST=mp.203.0.113.10.nip.io" in env_contents
+    assert "ARGO_HOST=argocd.203.0.113.10.nip.io" in env_contents
+
+    output_contents = out_file.read_text(encoding="utf-8")
+    assert "keycloak_url=http://kc.203.0.113.10.nip.io" in output_contents
+    assert "midpoint_url=http://mp.203.0.113.10.nip.io/midpoint" in output_contents
+    assert "argocd_url=http://argocd.203.0.113.10.nip.io" in output_contents
 
 
 def test_resolve_ingress_ip_explicit():

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -85,6 +85,7 @@ def test_params_env_defaults():
     assert "ingressClass=" in params
     assert "keycloakHost=" in params
     assert "midpointHost=" in params
+    assert "argocdHost=" in params
 
 
 def test_iam_secret_generators_use_opaque_type():


### PR DESCRIPTION
## Summary
- add an Argo CD ingress manifest and wire it into the bootstrap kustomization with replacements sourced from params.env
- extend the demo host configuration script and params file to manage an Argo CD hostname alongside keycloak and midpoint
- update the accompanying tests to cover the new host outputs and configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d8f8e5b8832b999c028ca74b1391