### PR TITLE
Fix bootstrap params env path

### DIFF
--- a/gitops/clusters/aks/bootstrap/kustomization.yaml
+++ b/gitops/clusters/aks/bootstrap/kustomization.yaml
@@ -13,7 +13,7 @@ configMapGenerator:
   - name: argocd-ingress-settings
     namespace: argocd
     envs:
-      - ../../apps/iam/params.env
+      - ../../../apps/iam/params.env
 replacements:
   - source:
       kind: ConfigMap


### PR DESCRIPTION
## Summary
- fix the Argo CD bootstrap config map generator to reference the shared params.env from gitops/apps/iam

## Testing
- not run (kustomize binary not available in CI container)


------
https://chatgpt.com/codex/tasks/task_e_68d7db6264ec832b89bdda69aa6d83c4