### PR TITLE
Fix bootstrap Argo CD ingress params path

### DIFF
--- a/gitops/clusters/aks/bootstrap/kustomization.yaml
+++ b/gitops/clusters/aks/bootstrap/kustomization.yaml
@@ -13,7 +13,7 @@ configMapGenerator:
   - name: argocd-ingress-settings
     namespace: argocd
     envs:
-      - ../../../apps/iam/params.env
+      - params.env
 replacements:
   - source:
       kind: ConfigMap

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -1,0 +1,4 @@
+# Keep values in sync with gitops/apps/iam/params.env so Argo CD ingress
+# matches the IAM application ingress settings.
+ingressClass=nginx
+argocdHost=argocd.20.61.182.128.nip.io


### PR DESCRIPTION
## Summary
- add a local params.env for the Argo CD bootstrap overlay
- stop referencing the IAM app params file from outside the bootstrap kustomization tree

## Testing
- kustomize build gitops/clusters/aks/bootstrap *(fails: kustomize not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d7dc918248832baea16932eb338418