### PR TITLE
Remove unsupported Keycloak ingress hostname configuration

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -36,7 +36,6 @@ spec:
   ingress:
     enabled: true
     className: nginx
-    hostname: kc.127.0.0.1.nip.io
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -42,7 +42,6 @@ replacements:
           name: rws-keycloak
         fieldPaths:
           - spec.hostname.hostname
-          - spec.ingress.hostname
   - source:
       kind: ConfigMap
       name: iam-ingress-settings

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -108,7 +108,6 @@ def test_iam_ingress_replacements_cover_all_targets():
     assert has_replacement("data.ingressClass", "Keycloak", "rws-keycloak", "spec.ingress.className")
     assert has_replacement("data.ingressClass", "Ingress", "midpoint", "spec.ingressClassName")
     assert has_replacement("data.keycloakHost", "Keycloak", "rws-keycloak", "spec.hostname.hostname")
-    assert has_replacement("data.keycloakHost", "Keycloak", "rws-keycloak", "spec.ingress.hostname")
     assert has_replacement("data.midpointHost", "Ingress", "midpoint", "spec.rules.0.host")
 
 


### PR DESCRIPTION
## Summary
- drop the unsupported `spec.ingress.hostname` field from the Keycloak manifest
- update the IAM kustomization replacements and structure test expectations to match the new schema

## Testing
- pytest tests/test_gitops_structure.py *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68d7de12ce48832ba28b7ae3023e1e48