### PR TITLE
Fix Keycloak health probes to use management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run the workflow **“04 - Configure demo hosts”** after the bootstrap finis
 
 - The GitOps tree lives under `gitops/`. Update manifests, commit, and let Argo CD reconcile the cluster. `kubectl apply` is only needed for the initial bootstrap.
 - `scripts/check_keycloak_first_class_fields.py` guards against regressing to deprecated Keycloak CLI flags – run it whenever you edit the Keycloak CR.
-- Keycloak's probes are now left at the operator defaults. The CRD rejects custom `httpGet` blocks on the probe definitions, so overriding them causes Argo CD to report a `ComparisonError`. When Argo CD reports the Keycloak resource as `Degraded`, confirm readiness via the `/health/ready` and `/health/live` endpoints with `kubectl port-forward`.
+- Keycloak's pod template now defines startup, readiness, and liveness probes that hit the management port (`9000`) on the `/health/started`, `/health/ready`, and `/health/live` endpoints recommended in the Keycloak observability guide. These probes are rendered through the operator's `unsupported.podTemplate` escape hatch so Argo CD can track them declaratively.
 - Need to rotate ingress hosts manually? Execute `python3 scripts/configure_demo_hosts.py --ingress-ip <EXTERNAL-IP>` and commit the updated parameters file.
 
 ### Debugging Argo CD repo permissions

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -41,6 +41,31 @@ spec:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  unsupported:
+    podTemplate:
+      spec:
+        containers:
+          - name: keycloak
+            startupProbe:
+              httpGet:
+                path: /health/started
+                port: 9000
+              failureThreshold: 60
+              periodSeconds: 5
+            livenessProbe:
+              httpGet:
+                path: /health/live
+                port: 9000
+              failureThreshold: 6
+              initialDelaySeconds: 30
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /health/ready
+                port: 9000
+              failureThreshold: 6
+              initialDelaySeconds: 10
+              periodSeconds: 5
   resources:
     requests:
       cpu: "250m"


### PR DESCRIPTION
## Summary
- point the Keycloak startup, readiness, and liveness probes at the management port (9000) using the /health/started, /health/ready, and /health/live endpoints
- document the management port requirement in the day-two operations guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7df56ecdc832bb2b7a3571e532bf2