### PR TITLE
Add Argo CD host handling to nip.io configuration workflow

### DIFF
--- a/.github/workflows/03_configure_demo_hosts.yml
+++ b/.github/workflows/03_configure_demo_hosts.yml
@@ -49,6 +49,7 @@ jobs:
 
           : "${KC_HOST:?KC_HOST was not exported by configure_demo_hosts.py}"
           : "${MP_HOST:?MP_HOST was not exported by configure_demo_hosts.py}"
+          : "${ARGOCD_HOST:?ARGOCD_HOST was not exported by configure_demo_hosts.py}"
 
           emit_diagnostics() {
             set +e
@@ -87,6 +88,7 @@ jobs:
           endpoints=(
             "http://${KC_HOST}"
             "http://${MP_HOST}/midpoint"
+            "https://${ARGOCD_HOST}"
           )
 
           for url in "${endpoints[@]}"; do
@@ -115,6 +117,7 @@ jobs:
           set -euo pipefail
           KC_HOST_VALUE="${KC_HOST:-}"
           MP_HOST_VALUE="${MP_HOST:-}"
+          ARGOCD_HOST_VALUE="${ARGOCD_HOST:-}"
           BRANCH_REF="${GITHUB_REF:-}"
           if git diff --quiet --exit-code -- gitops/apps/iam/params.env; then
             echo "Ingress host parameters already up to date; skipping commit."
@@ -122,7 +125,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add gitops/apps/iam/params.env
-            git commit -m "Update demo ingress hosts to ${KC_HOST_VALUE} and ${MP_HOST_VALUE}"
+            git commit -m "Update demo ingress hosts to ${KC_HOST_VALUE}, ${MP_HOST_VALUE}, and ${ARGOCD_HOST_VALUE}"
             if [[ "${BRANCH_REF}" == refs/heads/* ]]; then
               BRANCH_NAME="${BRANCH_REF#refs/heads/}"
               git push origin "HEAD:${BRANCH_NAME}"
@@ -138,4 +141,5 @@ jobs:
           echo "✅ Done. Open these URLs in your browser:"
           echo "🔗 Keycloak : ${{ steps.configure.outputs.keycloak_url }}"
           echo "🔗 midPoint : ${{ steps.configure.outputs.midpoint_url }}"
+          echo "🔗 Argo CD  : ${{ steps.configure.outputs.argocd_url }}"
           echo "🌐 External IP : ${EXTERNAL_IP:-unknown}"

--- a/scripts/configure_demo_hosts.py
+++ b/scripts/configure_demo_hosts.py
@@ -178,6 +178,7 @@ def main() -> int:
     if args.print_only:
         print(hosts.keycloak)
         print(hosts.midpoint)
+        print(hosts.argocd)
         return 0
 
     write_params(args.params_file, ingress_class, hosts)


### PR DESCRIPTION
## Summary
- ensure the configure nip.io workflow exports and validates the Argo CD host
- probe the Argo CD ingress endpoint and include it in the commit message and job summary
- update the helper script so print-only mode also reports the Argo CD host

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68d7e34159a0832bb62e938ce1ba6982