### PR TITLE
Fix Argo CD URL scheme in demo host configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When the IAM application reports `one or more synchronization tasks are not vali
 
 ## 3. Publish demo ingress hostnames
 
-Run the workflow **“04 - Configure demo hosts”** after the bootstrap finishes. The job calls [`scripts/configure_demo_hosts.py`](scripts/configure_demo_hosts.py) to discover the ingress IP, updates [`gitops/apps/iam/params.env`](gitops/apps/iam/params.env) with fresh `nip.io` hostnames, commits the change and prints the URLs.
+Run the workflow **“04 - Configure demo hosts”** after the bootstrap finishes. The job calls [`scripts/configure_demo_hosts.py`](scripts/configure_demo_hosts.py) to discover the ingress IP, updates [`gitops/apps/iam/params.env`](gitops/apps/iam/params.env) with fresh `nip.io` hostnames, commits the change and prints the URLs. Argo CD is exposed through an HTTP ingress (TLS terminates at the `argocd-server` service), so the generated Argo link intentionally uses `http://`.
 
 ## 4. Day-two tips
 

--- a/scripts/configure_demo_hosts.py
+++ b/scripts/configure_demo_hosts.py
@@ -195,7 +195,10 @@ def main() -> int:
         with open(github_output, "a", encoding="utf-8") as output_file:
             output_file.write(f"keycloak_url=http://{hosts.keycloak}\n")
             output_file.write(f"midpoint_url=http://{hosts.midpoint}/midpoint\n")
-            output_file.write(f"argocd_url=https://{hosts.argocd}\n")
+            # Argo CD terminates TLS at the upstream service; the ingress itself
+            # only serves HTTP. Surface the reachable scheme so the generated
+            # URL works out of the box.
+            output_file.write(f"argocd_url=http://{hosts.argocd}\n")
 
     return 0
 

--- a/tests/test_configure_demo_hosts.py
+++ b/tests/test_configure_demo_hosts.py
@@ -56,7 +56,7 @@ def test_main_updates_env_files(monkeypatch, tmp_path: Path):
 
     output_contents = out_file.read_text(encoding="utf-8")
     assert "midpoint_url=http://mp.203.0.113.10.nip.io/midpoint" in output_contents
-    assert "argocd_url=https://argocd.203.0.113.10.nip.io" in output_contents
+    assert "argocd_url=http://argocd.203.0.113.10.nip.io" in output_contents
 
 
 def test_resolve_ingress_ip_explicit():


### PR DESCRIPTION
## Summary
- ensure the demo host configurator outputs a working HTTP URL for Argo CD
- update the unit test and documentation to reflect the HTTP ingress behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7e42ac41c832ba9fe1f890e54ddd2