### PR TITLE
Fix diagnostics trap in nip.io workflow

### DIFF
--- a/.github/workflows/03_configure_demo_hosts.yml
+++ b/.github/workflows/03_configure_demo_hosts.yml
@@ -47,12 +47,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          : "${KC_HOST:?KC_HOST was not exported by configure_demo_hosts.py}"
-          : "${MP_HOST:?MP_HOST was not exported by configure_demo_hosts.py}"
-          : "${ARGOCD_HOST:?ARGOCD_HOST was not exported by configure_demo_hosts.py}"
-
           emit_diagnostics() {
-            set +e
+            set +eu
             echo "::group::Ingress diagnostics"
             echo "📡 Inspecting ingress-nginx service status"
             kubectl -n ingress-nginx get svc ingress-nginx-controller -o wide || true
@@ -80,10 +76,14 @@ jobs:
               echo "openssl not available on runner"
             fi
             echo "::endgroup::"
-            set -e
+            set -eu
           }
 
           trap 'emit_diagnostics' ERR
+
+          : "${KC_HOST:?KC_HOST was not exported by configure_demo_hosts.py}"
+          : "${MP_HOST:?MP_HOST was not exported by configure_demo_hosts.py}"
+          : "${ARGOCD_HOST:?ARGOCD_HOST was not exported by configure_demo_hosts.py}"
 
           endpoints=(
             "http://${KC_HOST}"


### PR DESCRIPTION
## Summary
- ensure the ingress diagnostics trap is registered before validating exported hosts
- allow the diagnostics function to run even when host variables are missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e63acc34832b961d28017f0251b6