### PR TITLE
Enhance diagnostics when Keycloak pods are missing

### DIFF
--- a/scripts/collect_keycloak_diagnostics.sh
+++ b/scripts/collect_keycloak_diagnostics.sh
@@ -76,6 +76,13 @@ mapfile -t keycloak_pods < <(
 
 if ((${#keycloak_pods[@]} == 0)); then
   error "No Keycloak pods found with selector '${KEYCLOAK_POD_SELECTOR}' in namespace '${KEYCLOAK_NAMESPACE}'"
+
+  run_cmd "Pods in namespace ${KEYCLOAK_NAMESPACE} (showing labels)" \
+    kubectl get pods -n "${KEYCLOAK_NAMESPACE}" --show-labels
+
+  run_cmd "Keycloak workloads in ${KEYCLOAK_NAMESPACE}" \
+    kubectl get statefulsets,deployments -n "${KEYCLOAK_NAMESPACE}" \
+      --selector="${KEYCLOAK_POD_SELECTOR}" --show-labels
 else
   for pod in "${keycloak_pods[@]}"; do
     run_cmd "Describe Keycloak pod ${pod}" \


### PR DESCRIPTION
## Summary
- list all pods in the Keycloak namespace with labels when the targeted pods are absent
- capture statefulset and deployment status for the Keycloak selector to aid troubleshooting

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7ebf9d1c8832ba1f25dd6356fd620