### PR TITLE
Add explicit labels to Keycloak pod template

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -42,6 +42,11 @@ spec:
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
   unsupported:
     podTemplate:
+      metadata:
+        labels:
+          app: keycloak
+          app.kubernetes.io/name: keycloak
+          app.kubernetes.io/instance: rws-keycloak
       spec:
         containers:
           - name: keycloak


### PR DESCRIPTION
## Summary
- add explicit Keycloak pod labels so diagnostics can find the workload managed by the operator

## Testing
- python3 scripts/check_keycloak_first_class_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ee1d8808832b97ec951a318b2703