### PR TITLE
Disable Keycloak strict HTTPS enforcement

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -33,6 +33,7 @@ spec:
     hostname: kc.127.0.0.1.nip.io
     strict: false
     strictBackchannel: false
+    strictHttps: false
   ingress:
     enabled: true
     className: nginx


### PR DESCRIPTION
## Summary
- disable strict HTTPS enforcement in the Keycloak hostname configuration via the dedicated CR field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7fec4acd8832ba855ce17833f5e49