### PR TITLE
Align Keycloak operator namespace with managed stack

### DIFF
--- a/gitops/clusters/aks/apps/keycloak-operator.application.yaml
+++ b/gitops/clusters/aks/apps/keycloak-operator.application.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: platform
   destination:
-    namespace: keycloak
+    namespace: iam
     server: https://kubernetes.default.svc
   source:
     repoURL: https://github.com/keycloak/keycloak-k8s-resources.git


### PR DESCRIPTION
## Summary
- deploy the Keycloak operator into the iam namespace so it watches the Keycloak CRs managed by the IAM application

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68d80e6139ec832b81ce75138d186589