### PR TITLE
Fix ingress diagnostics trap in configure workflow

### DIFF
--- a/.github/workflows/03_configure_demo_hosts.yml
+++ b/.github/workflows/03_configure_demo_hosts.yml
@@ -103,7 +103,9 @@ jobs:
               sleep 15
               if [[ ${attempt} -eq 2 ]]; then
                 echo "❌ Unable to reach ${url} after ${attempt} attempts."
-                exit 1
+                # Trigger the ERR trap so diagnostics are emitted before the
+                # job exits; `exit` bypasses the trap in bash.
+                false
               fi
             done
             echo "::endgroup::"


### PR DESCRIPTION
## Summary
- ensure the ingress diagnostics trap runs by failing with a command that triggers the ERR trap instead of exiting directly when endpoint probes never succeed

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d80cfdaa74832b93e624ceb42a5f1f