### PR TITLE
Fix Keycloak hostname strict https option schema usage

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -12,6 +12,8 @@ spec:
       value: "true"
     - name: metrics-enabled
       value: "true"
+    - name: hostname-strict-https
+      value: "false"
   features:
     enabled:
       - token-exchange
@@ -33,7 +35,6 @@ spec:
     hostname: kc.127.0.0.1.nip.io
     strict: false
     strictBackchannel: false
-    strictHttps: false
   ingress:
     enabled: true
     className: nginx


### PR DESCRIPTION
## Summary
- remove the unsupported `spec.hostname.strictHttps` field from the Keycloak CR manifest
- configure the hostname strict HTTPS behavior through the supported additional option instead

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d812807fa8832bad4b4c7d4f0d6f28