### PR TITLE
Fix Argo CD ingress probe protocol

### DIFF
--- a/.github/workflows/03_configure_demo_hosts.yml
+++ b/.github/workflows/03_configure_demo_hosts.yml
@@ -88,7 +88,7 @@ jobs:
           endpoints=(
             "http://${KC_HOST}"
             "http://${MP_HOST}/midpoint"
-            "https://${ARGOCD_HOST}"
+            "http://${ARGOCD_HOST}"
           )
 
           for url in "${endpoints[@]}"; do


### PR DESCRIPTION
## Summary
- update the Configure demo hosts workflow to probe the Argo CD ingress over HTTP instead of HTTPS

## Testing
- pytest *(fails: missing yaml dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d812b1f534832bb1299c485076b801