### PR TITLE
fix: update keycloak diagnostics namespace

### DIFF
--- a/docs/troubleshooting/iam-sync-timeout.md
+++ b/docs/troubleshooting/iam-sync-timeout.md
@@ -43,7 +43,9 @@ commands manually, follow the steps below.
    ```
 5. If the CRDs are missing, inspect the operator controller logs for installation errors:
    ```bash
-   kubectl logs deployment/keycloak-operator -n keycloak --since=15m
+   kubectl logs deployment/keycloak-operator -n iam --since=15m
+   # Adjust the namespace flag (or set KEYCLOAK_OPERATOR_NAMESPACE for the
+   # diagnostics script) if your installation uses a different location.
    ```
 
 Collecting this data before attempting a fix ensures we know whether the failure is caused by missing CRDs or by a different

--- a/scripts/collect_keycloak_diagnostics.sh
+++ b/scripts/collect_keycloak_diagnostics.sh
@@ -40,6 +40,7 @@ require_cmd kubectl
 require_cmd jq
 
 KEYCLOAK_NAMESPACE=${KEYCLOAK_NAMESPACE:-iam}
+KEYCLOAK_OPERATOR_NAMESPACE=${KEYCLOAK_OPERATOR_NAMESPACE:-${KEYCLOAK_NAMESPACE}}
 KEYCLOAK_NAME=${KEYCLOAK_NAME:-rws-keycloak}
 KEYCLOAK_POD_SELECTOR=${KEYCLOAK_POD_SELECTOR:-app=keycloak}
 KEYCLOAK_MGMT_PORT=${KEYCLOAK_MGMT_PORT:-9000}
@@ -103,4 +104,4 @@ else
 fi
 
 run_cmd "Keycloak operator logs (last 15m)" \
-  kubectl logs deployment/keycloak-operator -n keycloak --since=15m
+  kubectl logs deployment/keycloak-operator -n "${KEYCLOAK_OPERATOR_NAMESPACE}" --since=15m


### PR DESCRIPTION
## Summary
- default the keycloak operator log collection to the iam namespace while keeping it overrideable
- refresh the IAM sync timeout runbook to reference the new namespace and highlight the override knob

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8142fc650832bbf249c6e4156fbd0