### PR TITLE
Enable Keycloak management port for health probes

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -12,6 +12,8 @@ spec:
       value: "true"
     - name: metrics-enabled
       value: "true"
+    - name: http-management-enabled
+      value: "true"
     - name: hostname-strict-https
       value: "false"
   features:


### PR DESCRIPTION
## Summary
- enable the Keycloak management HTTP port so the startup, liveness, and readiness probes can reach the health endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d813c995ec832b8d9426b0cfdd1063