### PR TITLE
Fix Keycloak hostname strict HTTPS option to match CRD

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -14,8 +14,6 @@ spec:
       value: "true"
     - name: http-management-enabled
       value: "true"
-    - name: hostname-strict-https
-      value: "false"
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- remove the unsupported hostname-strict-https additional option from the Keycloak custom resource so that the CR schema remains valid

## Testing
- scripts/check_keycloak_first_class_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68d81831dbf8832b85dc061a1974f977