### PR TITLE
Remove unsupported Keycloak strict HTTPS option

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -12,8 +12,6 @@ spec:
       value: "true"
     - name: metrics-enabled
       value: "true"
-    - name: hostname-strict-https
-      value: "false"
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- drop the hostname-strict-https additional option from the Keycloak manifest so that only typed hostname settings are used

## Testing
- python3 scripts/check_keycloak_first_class_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68d813ef7808832ba17790b5acc63fc6