### PR TITLE
Allow Keycloak management probes from kubelet

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -14,6 +14,8 @@ spec:
       value: "true"
     - name: http-management-enabled
       value: "true"
+    - name: http-management-allowed-hosts
+      value: "*"
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- allow the Keycloak management interface to accept kubelet-sourced health probes by permitting all hosts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8292c4cbc832b8906deaf5a7084aa