### PR TITLE
Enable Keycloak optimized startup defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run the workflow **“04 - Configure demo hosts”** after the bootstrap finis
 
 - The GitOps tree lives under `gitops/`. Update manifests, commit, and let Argo CD reconcile the cluster. `kubectl apply` is only needed for the initial bootstrap.
 - `scripts/check_keycloak_first_class_fields.py` guards against regressing to deprecated Keycloak CLI flags – run it whenever you edit the Keycloak CR.
-- Keycloak's pod template now defines startup, readiness, and liveness probes that hit the management port (`9000`) on the `/health/started`, `/health/ready`, and `/health/live` endpoints recommended in the Keycloak observability guide. These probes are rendered through the operator's `unsupported.podTemplate` escape hatch so Argo CD can track them declaratively.
+- Keycloak runs with the operator's optimized startup path (`startOptimized: true`) so restarts skip the build step, and we rely on the operator's default probes against the management endpoints.
 
 - Need to rotate ingress hosts manually? Execute `python3 scripts/configure_demo_hosts.py --ingress-ip <EXTERNAL-IP>` and commit the updated parameters file.
 

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   image: quay.io/keycloak/keycloak:26.3.5
   instances: 1
-  startOptimized: false
+  startOptimized: true
   additionalOptions:
     - name: health-enabled
       value: "true"
@@ -42,36 +42,6 @@ spec:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
-  unsupported:
-    podTemplate:
-      metadata:
-        labels:
-          app: keycloak
-          app.kubernetes.io/name: keycloak
-          app.kubernetes.io/instance: rws-keycloak
-      spec:
-        containers:
-          - name: keycloak
-            startupProbe:
-              httpGet:
-                path: /health/started
-                port: 9000
-              failureThreshold: 60
-              periodSeconds: 5
-            livenessProbe:
-              httpGet:
-                path: /health/live
-                port: 9000
-              failureThreshold: 6
-              initialDelaySeconds: 30
-              periodSeconds: 10
-            readinessProbe:
-              httpGet:
-                path: /health/ready
-                port: 9000
-              failureThreshold: 6
-              initialDelaySeconds: 10
-              periodSeconds: 5
   resources:
     requests:
       cpu: "250m"


### PR DESCRIPTION
## Summary
- enable the Keycloak CR's optimized startup mode to skip rebuilds on restarts
- remove the unsupported podTemplate probe overrides so the operator manages defaults
- document the new startup behavior and reliance on operator probes in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8297ce200832b974319519f70a75b