### PR TITLE
Expose Keycloak management endpoint

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -16,6 +16,8 @@ spec:
       value: "true"
     - name: http-management-allowed-hosts
       value: "*"
+    - name: http-management-host
+      value: "0.0.0.0"
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- configure the Keycloak CR to bind the management interface on all addresses so health checks can reach it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82eddad1c832b805d7aa75afc2ca1