### PR TITLE
Disable Keycloak optimized startup on first boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run the workflow **“04 - Configure demo hosts”** after the bootstrap finis
 
 - The GitOps tree lives under `gitops/`. Update manifests, commit, and let Argo CD reconcile the cluster. `kubectl apply` is only needed for the initial bootstrap.
 =======
-- Keycloak runs with the operator's optimized startup path (`startOptimized: true`) so restarts skip the build step, and we rely on the operator's default probes against the management endpoints.
+- Keycloak starts without the optimized flag on first boot (`startOptimized: false`) so that the stock container image performs its initial build step successfully. After the first run you can bake a pre-built image and re-enable the optimized path for faster restarts.
 
 
 - Need to rotate ingress hosts manually? Execute `python3 scripts/configure_demo_hosts.py --ingress-ip <EXTERNAL-IP>` and commit the updated parameters file.

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   image: quay.io/keycloak/keycloak:26.3.5
   instances: 1
-  startOptimized: true
+  startOptimized: false
   additionalOptions:
     - name: health-enabled
       value: "true"


### PR DESCRIPTION
## Summary
- disable the optimized startup mode on the Keycloak CR so the stock image can build successfully on first boot
- document in the README that the deployment now relies on a non-optimized first start and how to re-enable it after baking an image

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d837990f88832bb9522fe73a1bf555