### PR TITLE
Remove invalid Keycloak management flag causing CrashLoop

### DIFF
--- a/docs/troubleshooting/keycloak-crashloop.md
+++ b/docs/troubleshooting/keycloak-crashloop.md
@@ -1,0 +1,38 @@
+# Keycloak pod stuck in `CrashLoopBackOff`
+
+## Symptoms
+
+* The Keycloak StatefulSet pods restart repeatedly with `ExitCode: 2` within a few seconds.
+* `kubectl describe pod rws-keycloak-0 -n iam` shows the Keycloak container waiting with the reason `CrashLoopBackOff`.
+* The Keycloak operator controller logs report `Found unhealthy container on pod iam/rws-keycloak-0`.
+
+## Why this happens
+
+An exit code of `2` means the Keycloak bootstrap script failed before the server started. In practice this is almost
+always caused by an invalid CLI flag passed through `spec.additionalOptions`. In the 26.x releases the server rejects
+unknown management options such as `--http-management-allowed-hosts` and terminates immediately, which matches the
+behaviour seen in incident IAM-1137.
+
+## Gather diagnostics first
+
+Run the helper script to capture the full context (pod descriptions, current and previous logs, operator output, and
+management endpoints):
+
+```bash
+./scripts/collect_keycloak_diagnostics.sh
+```
+
+Look for log lines similar to the following in the `previous container` section for the crashing pod:
+
+```
+Unknown option: '--http-management-allowed-hosts'
+```
+
+## Apply the fix
+
+Remove the invalid option from `gitops/apps/iam/keycloak/keycloak.yaml`. The operator will roll out a new pod that starts
+successfully with the remaining management options (`--http-management-enabled` and `--http-management-host=0.0.0.0`). No
+additional configuration is required because the management service already binds to all network interfaces.
+
+If a future version of Keycloak introduces a replacement flag, add it back only after confirming it appears in the
+[official configuration reference](https://github.com/keycloak/keycloak/blob/main/docs/guides/server/all-config.adoc).

--- a/docs/troubleshooting/keycloak-health-degraded.md
+++ b/docs/troubleshooting/keycloak-health-degraded.md
@@ -1,5 +1,9 @@
 # Keycloak health endpoint reports `NOT READY`
 
+> ℹ️ If the Keycloak pod exits immediately with `ExitCode: 2` and the controller reports `CrashLoopBackOff`,
+> follow [Keycloak pod stuck in `CrashLoopBackOff`](./keycloak-crashloop.md) instead. The steps below assume the
+> server is running but the readiness probe is failing.
+
 ## Symptoms
 
 * The Argo CD application shows the IAM stack as `sync=OutOfSync`, `health=Degraded`, `phase=Running`.

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -14,8 +14,6 @@ spec:
       value: "true"
     - name: http-management-enabled
       value: "true"
-    - name: http-management-allowed-hosts
-      value: "*"
     - name: http-management-host
       value: "0.0.0.0"
   features:

--- a/scripts/collect_keycloak_diagnostics.sh
+++ b/scripts/collect_keycloak_diagnostics.sh
@@ -96,6 +96,9 @@ else
     run_cmd "Keycloak pod logs (${pod}, last 200 lines)" \
       kubectl logs "${pod}" -n "${KEYCLOAK_NAMESPACE}" --tail=200
 
+    run_cmd "Keycloak pod logs (${pod}, previous container)" \
+      kubectl logs "${pod}" -n "${KEYCLOAK_NAMESPACE}" --tail=200 --previous
+
     for endpoint in /health /health/live /health/ready /health/started; do
       run_cmd "Keycloak health endpoint (${pod}, ${endpoint})" bash -c \
         "kubectl get --raw \"/api/v1/namespaces/${KEYCLOAK_NAMESPACE}/pods/${pod}:${KEYCLOAK_MGMT_PORT}/proxy${endpoint}\" | jq '.'"


### PR DESCRIPTION
## Summary
- drop the unsupported `http-management-allowed-hosts` Keycloak option that caused the pod to exit with status 2
- enhance the Keycloak diagnostics helper to capture previous-container logs for crash analysis
- document the CrashLoopBackOff scenario and cross-link from the existing Keycloak troubleshooting guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d83b08c924832babc535dc08a9b463