### PR TITLE
Fix Keycloak TLS JDBC configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Trigger the workflow **“01 - Provision AKS with Terraform”** (`.github/wor
    - Optionally configure repository credentials when the repo is private.
    - Validate the GitOps manifests via the unit tests before touching the cluster.
    - Create the database and admin secrets in the `iam` namespace.
-   - Configure Keycloak to require TLS (`sslmode=require`) when connecting to the CloudNativePG primary so the readiness health
-     check succeeds even when the database enforces encrypted connections.
+   - Configure Keycloak with an explicit JDBC URL that enforces TLS (`?sslmode=require`) when connecting to the CloudNativePG pri
+     mary so the readiness health check succeeds even when the database enforces encrypted connections.
    - Normalise the Azure Blob credentials into the `cnpg-azure-backup` secret using `scripts/normalize_azure_storage_secret.py`.
    - Apply the GitOps tree (`gitops/clusters/aks`) so Argo CD manages addons (cert-manager, CloudNativePG operator, ingress-nginx, Keycloak operator) and the IAM workloads (CloudNativePG cluster, Keycloak, midPoint).
    - Wait for all applications to report `Synced` and `Healthy`.

--- a/docs/troubleshooting/keycloak-health-degraded.md
+++ b/docs/troubleshooting/keycloak-health-degraded.md
@@ -69,7 +69,7 @@ For more examples of response payloads, consult the [Keycloak health documentati
        bash -lc "export PGPASSWORD='$PASS'; psql -h iam-db-rw.iam.svc.cluster.local -U '$USER' -d keycloak -c '\\conninfo'"
      ```
   3. If the command returns `\conninfo` without an error, the credentials are correct; otherwise update either the database user or the secret so that they match.
-* **TLS enforcement errors:** If the readiness payload or Keycloak logs mention `SSL off` or a missing `pg_hba.conf` entry, confirm the manifest still applies the `--db-url-properties=sslmode=require` flag (added under `spec.additionalOptions`). Without that flag the server attempts an unencrypted connection, which CloudNativePG rejects when TLS is mandatory.
+* **TLS enforcement errors:** If the readiness payload or Keycloak logs mention `SSL off` or a missing `pg_hba.conf` entry, confirm the manifest still applies the `--db-url=jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require` flag (added under `spec.additionalOptions`). Without that flag the server attempts an unencrypted connection, which CloudNativePG rejects when TLS is mandatory.
 * **Schema migrations:** Monitor the pod logs until migrations complete. Large schema updates can temporarily keep the readiness probe `DOWN`; do not restart the pod unless the logs show a fatal error.
 * **Missing secrets or config:** Confirm every reference in `gitops/apps/iam/keycloak/keycloak.yaml` and the realm import exists in the `iam` namespace. Re-run the bootstrap workflow if secrets are missing.
 

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -16,8 +16,8 @@ spec:
       value: "true"
     - name: http-management-host
       value: "0.0.0.0"
-    - name: db-url-properties
-      value: sslmode=require
+    - name: db-url
+      value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- set the Keycloak CR to pass an explicit JDBC URL that enforces sslmode=require
- update operator runbook and README to reference the new db-url flag

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d85332d4c8832b9ee3b61e1a414207