### PR TITLE
Configure Keycloak proxy headers

### DIFF
--- a/docs/troubleshooting/keycloak-proxy-warning.md
+++ b/docs/troubleshooting/keycloak-proxy-warning.md
@@ -1,0 +1,38 @@
+# Keycloak reports insecure proxy headers configuration
+
+## Symptoms
+
+* Keycloak pod logs include warnings similar to:
+  ```
+  WARNING: Likely misconfiguration detected. With HTTPS not enabled, `proxy-headers` unset, and a non-URL `hostname`, the server is running in an insecure context.
+  WARNING: Hostname v1 options [hostname-strict-backchannel] are still in use, please review your configuration
+  ```
+* Browser sessions fail to persist or management requests routed through an ingress receive `403` errors because Keycloak misidentifies the request origin.
+
+## Why this happens
+
+When the Keycloak operator renders the Quarkus distribution without an explicit proxy mode, the server assumes it is directly exposed on the public internet. In our deployment, traffic reaches Keycloak through NGINX Ingress over HTTPS and is then forwarded to the pod over plain HTTP. Without the `proxy`/`proxy-headers` options, Keycloak does not trust the `X-Forwarded-*` headers provided by the ingress controller. As a result the server believes it is running in an insecure context and warns about the missing configuration. It may also fall back to legacy hostname options and break backchannel communication with some clients.
+
+## Fix
+
+Update the GitOps source of truth so Keycloak honours the headers injected by the ingress controller:
+
+1. Edit [`gitops/apps/iam/keycloak/keycloak.yaml`](../../gitops/apps/iam/keycloak/keycloak.yaml) and ensure the following entries exist under `spec.additionalOptions`:
+   ```yaml
+   - name: proxy
+     value: edge
+   - name: proxy-headers
+     value: xforwarded
+   ```
+   The `edge` proxy mode tells Keycloak to expect TLS termination at the ingress boundary, while `xforwarded` enables parsing of the forwarded headers.
+2. Commit and push the change. Argo CD will roll the Keycloak StatefulSet to pick up the new configuration.
+3. After the rollout completes, confirm the warning disappeared:
+   ```bash
+   kubectl logs statefulset/rws-keycloak -n iam | rg "Likely misconfiguration"
+   ```
+   The command should return no matches once the server restarts with the updated options.
+
+## Additional hardening
+
+* If you intend to expose Keycloak directly on the internet, configure TLS by setting `spec.http.tlsSecret` and disable plaintext `httpEnabled` traffic.
+* Set `spec.hostname.strictBackchannel` to `true` once all clients are updated to honour the canonical hostname. This removes the `hostname-strict-backchannel` deprecation warning.

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -18,6 +18,10 @@ spec:
       value: "0.0.0.0"
     - name: db-url-properties
       value: sslmode=require
+    - name: proxy
+      value: edge
+    - name: proxy-headers
+      value: xforwarded
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- configure the Keycloak custom resource to trust ingress proxy headers
- document how to remediate the Keycloak insecure proxy warning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d853547b20832b9e63c0b31e021ec7