### PR TITLE
Configure Keycloak proxy headers for ingress deployments

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -18,6 +18,10 @@ spec:
       value: "0.0.0.0"
     - name: db-url-properties
       value: sslmode=require
+    - name: proxy-headers
+      value: xforwarded
+    - name: hostname-url
+      value: https://kc.127.0.0.1.nip.io
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- add proxy header support to the Keycloak CR so ingress-forwarded HTTPS requests are trusted
- configure the hostname URL to advertise the public HTTPS endpoint and avoid insecure context warnings

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d853547b20832b9e63c0b31e021ec7