### PR TITLE
Fix Keycloak db url properties

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -16,8 +16,6 @@ spec:
       value: "true"
     - name: http-management-host
       value: "0.0.0.0"
-    - name: db-url
-      value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require
     - name: proxy
       value: edge
     - name: proxy-headers
@@ -37,6 +35,7 @@ spec:
     passwordSecret:
       name: keycloak-db-app
       key: password
+    urlProperties: "?sslmode=require"
   http:
     httpEnabled: true
   hostname:


### PR DESCRIPTION
## Summary
- remove the custom db-url additional option in favour of the structured database configuration
- set the database urlProperties to include the required leading `?` so sslmode is applied correctly

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d859e25d4c832bbbc4ee87b1225a18