### PR TITLE
Fix Keycloak DB URL configuration

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -16,8 +16,6 @@ spec:
       value: "true"
     - name: http-management-host
       value: "0.0.0.0"
-    - name: db-url
-      value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require
     - name: proxy
       value: edge
     - name: proxy-headers
@@ -31,6 +29,7 @@ spec:
     port: 5432
     database: keycloak
     schema: public
+    urlProperties: "?sslmode=require"
     usernameSecret:
       name: keycloak-db-app
       key: username


### PR DESCRIPTION
## Summary
- ensure the Keycloak CR uses `spec.db.urlProperties` with a leading `?` for SSL mode settings
- drop the redundant `additionalOptions` entry for `db-url` so the operator relies on structured DB configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d859e25d4c832bbbc4ee87b1225a18