### PR TITLE
Fix Keycloak TLS database connection string

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -20,6 +20,8 @@ spec:
       value: edge
     - name: proxy-headers
       value: xforwarded
+    - name: db-url
+      value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require
   features:
     enabled:
       - token-exchange
@@ -35,7 +37,6 @@ spec:
     passwordSecret:
       name: keycloak-db-app
       key: password
-    urlProperties: "?sslmode=require"
   http:
     httpEnabled: true
   hostname:


### PR DESCRIPTION
## Summary
- add the explicit db-url additional option so Keycloak uses a TLS-enforced JDBC URL
- remove the broken urlProperties field that produced an invalid database name

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d85bf84dd8832bb312ce42e61d0d78