### PR TITLE
Enforce Keycloak Postgres TLS via sslMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ Trigger the workflow **“01 - Provision AKS with Terraform”** (`.github/wor
    - Optionally configure repository credentials when the repo is private.
    - Validate the GitOps manifests via the unit tests before touching the cluster.
    - Create the database and admin secrets in the `iam` namespace.
-   - Configure Keycloak with an explicit JDBC URL that enforces TLS (`?sslmode=require`) when connecting to the CloudNativePG pri
-     mary so the readiness health check succeeds even when the database enforces encrypted connections.
+   - Configure Keycloak to enforce TLS (`spec.db.sslMode: require`) when connecting to the CloudNativePG primary so the readiness health check succeeds even when the database enforces encrypted connections.
    - Normalise the Azure Blob credentials into the `cnpg-azure-backup` secret using `scripts/normalize_azure_storage_secret.py`.
    - Apply the GitOps tree (`gitops/clusters/aks`) so Argo CD manages addons (cert-manager, CloudNativePG operator, ingress-nginx, Keycloak operator) and the IAM workloads (CloudNativePG cluster, Keycloak, midPoint).
    - Wait for all applications to report `Synced` and `Healthy`.

--- a/docs/troubleshooting/keycloak-health-degraded.md
+++ b/docs/troubleshooting/keycloak-health-degraded.md
@@ -69,7 +69,7 @@ For more examples of response payloads, consult the [Keycloak health documentati
        bash -lc "export PGPASSWORD='$PASS'; psql -h iam-db-rw.iam.svc.cluster.local -U '$USER' -d keycloak -c '\\conninfo'"
      ```
   3. If the command returns `\conninfo` without an error, the credentials are correct; otherwise update either the database user or the secret so that they match.
-* **TLS enforcement errors:** If the readiness payload or Keycloak logs mention `SSL off` or a missing `pg_hba.conf` entry, confirm the manifest still applies the `--db-url=jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require` flag (added under `spec.additionalOptions`). Without that flag the server attempts an unencrypted connection, which CloudNativePG rejects when TLS is mandatory.
+* **TLS enforcement errors:** If the readiness payload or Keycloak logs mention `SSL off` or a missing `pg_hba.conf` entry, confirm the manifest still sets `spec.db.sslMode: require`. Without that field the server attempts an unencrypted connection, which CloudNativePG rejects when TLS is mandatory.
 * **Schema migrations:** Monitor the pod logs until migrations complete. Large schema updates can temporarily keep the readiness probe `DOWN`; do not restart the pod unless the logs show a fatal error.
 * **Missing secrets or config:** Confirm every reference in `gitops/apps/iam/keycloak/keycloak.yaml` and the realm import exists in the `iam` namespace. Re-run the bootstrap workflow if secrets are missing.
 

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -20,8 +20,6 @@ spec:
       value: edge
     - name: proxy-headers
       value: xforwarded
-    - name: db-url
-      value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require
   features:
     enabled:
       - token-exchange
@@ -31,7 +29,7 @@ spec:
     port: 5432
     database: keycloak
     schema: public
-    urlProperties: "?sslmode=require"
+    sslMode: require
     usernameSecret:
       name: keycloak-db-app
       key: username

--- a/scripts/check_keycloak_first_class_fields.py
+++ b/scripts/check_keycloak_first_class_fields.py
@@ -38,6 +38,15 @@ def main() -> int:
                     "Keycloak manifest must drive the database connection through typed host/port/database fields instead of spec.db.url."
                 )
                 break
+
+        ssl_mode_match = re.search(r"^\s*sslMode:\s*(?P<value>\S+)", body, re.MULTILINE)
+        if ssl_mode_match is None:
+            errors.append("Keycloak manifest must set spec.db.sslMode to enforce TLS for database connections.")
+        elif ssl_mode_match.group("value") != "require":
+            errors.append(
+                "Keycloak manifest must enforce TLS via spec.db.sslMode: require (found"
+                f" '{ssl_mode_match.group('value')}')."
+            )
     else:
         errors.append("Unable to locate spec.db block in Keycloak manifest; update the checker if the manifest moved.")
 


### PR DESCRIPTION
## Summary
- switch the Keycloak CR to use the typed `spec.db.sslMode: require` field instead of the `--db-url` flag
- document the sslMode requirement in the bootstrap README and Keycloak troubleshooting guide
- harden the Keycloak manifest checker to require `spec.db.sslMode: require`

## Testing
- `python3 scripts/check_keycloak_first_class_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_68d85f9e6614832b88253b2fd3b7e65c