### PR TITLE
Fix Keycloak Postgres SSL mode configuration

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -29,14 +29,13 @@ spec:
     port: 5432
     database: keycloak
     schema: public
-    urlProperties: "?sslmode=require"
+    urlProperties: "sslmode=require"
     usernameSecret:
       name: keycloak-db-app
       key: username
     passwordSecret:
       name: keycloak-db-app
       key: password
-    urlProperties: "?sslmode=require"
   http:
     httpEnabled: true
   hostname:


### PR DESCRIPTION
## Summary
- remove the stray question mark from the Keycloak database URL properties so the operator no longer appends it to the database name
- keep the database credentials configuration unchanged

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d85e3e3c50832b962c52d622ff0ffb