### PR TITLE
Schedule nightly ingress host refresh

### DIFF
--- a/.github/workflows/03_configure_demo_hosts.yml
+++ b/.github/workflows/03_configure_demo_hosts.yml
@@ -1,6 +1,8 @@
 name: "03 - Configure demo hosts (nip.io) & Ingresses"
 
 on:
+  schedule:
+    - cron: '15 3 * * *'
   workflow_dispatch:
     inputs:
       RESOURCE_GROUP:
@@ -19,6 +21,9 @@ permissions:
 jobs:
   configure:
     runs-on: ubuntu-latest
+    env:
+      RESOURCE_GROUP: ${{ github.event.inputs.RESOURCE_GROUP || vars.AKS_RESOURCE_GROUP || 'rwsdemo-rg' }}
+      AKS_NAME: ${{ github.event.inputs.AKS_NAME || vars.AKS_NAME || 'rwsdemo-aks' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,8 +37,8 @@ jobs:
       - name: Get AKS credentials
         uses: azure/aks-set-context@v4
         with:
-          resource-group: ${{ inputs.RESOURCE_GROUP }}
-          cluster-name: ${{ inputs.AKS_NAME }}
+          resource-group: ${{ env.RESOURCE_GROUP }}
+          cluster-name: ${{ env.AKS_NAME }}
 
       - name: Configure demo ingress hosts
         id: configure

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ When the IAM application reports `one or more synchronization tasks are not vali
 
 Run the workflow **“04 - Configure demo hosts”** after the bootstrap finishes. The job calls [`scripts/configure_demo_hosts.py`](scripts/configure_demo_hosts.py) to discover the ingress IP, updates [`gitops/apps/iam/params.env`](gitops/apps/iam/params.env) with fresh `nip.io` hostnames, commits the change and prints the URLs. Argo CD is exposed through an HTTP ingress (TLS terminates at the `argocd-server` service), so the generated Argo link intentionally uses `http://`.
 
+To prevent drift, the workflow now also runs every night with the default AKS resource group and cluster name (or the values configured in repository variables `AKS_RESOURCE_GROUP`/`AKS_NAME`). Each scheduled run re-applies the host discovery script and commits any changes automatically, so stale ingress hostnames self-heal without manual intervention.
+
 ## 4. Day-two tips
 
 - The GitOps tree lives under `gitops/`. Update manifests, commit, and let Argo CD reconcile the cluster. `kubectl apply` is only needed for the initial bootstrap.

--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.20.61.182.128.nip.io
-midpointHost=mp.20.61.182.128.nip.io
-argocdHost=argocd.20.61.182.128.nip.io
+keycloakHost=kc.98.64.116.233.nip.io
+midpointHost=mp.98.64.116.233.nip.io
+argocdHost=argocd.98.64.116.233.nip.io

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.20.61.182.128.nip.io
-midpointHost=mp.20.61.182.128.nip.io
-argocdHost=argocd.20.61.182.128.nip.io
+keycloakHost=kc.98.64.116.233.nip.io
+midpointHost=mp.98.64.116.233.nip.io
+argocdHost=argocd.98.64.116.233.nip.io


### PR DESCRIPTION
## Summary
- add a nightly schedule to the configure-demo-hosts workflow and default AKS context fallbacks so automated runs can reconcile ingress IP drift
- refresh the committed nip.io host parameters to the current 98.64.116.233 address and document the auto-healing job in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d91aea5764832bb9f89effd96c95cf