### PR TITLE
Align Keycloak DB secret usage with CNPG managed credentials

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -34,12 +34,8 @@ spec:
     vendor: postgres
     url: "jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require"
     schema: public
-    usernameSecret:
-      name: keycloak-db-app
-      key: username
-    passwordSecret:
-      name: keycloak-db-app
-      key: password
+    usernameSecret: { name: keycloak-db-app, key: username }
+    passwordSecret: { name: keycloak-db-app, key: password }
 
   ingress:
     enabled: true


### PR DESCRIPTION
## Summary
- update the Keycloak CR database configuration to reference the managed `keycloak-db-app` secret inline so credentials stay aligned with CNPG

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91f8c9d50832bb397eb14891ad47c