### PR TITLE
Enable cert-manager for ingress-nginx admission webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ controller logs, inspect the `/health/ready` payload and resolve the underlying 
 
 When the IAM application reports `one or more synchronization tasks are not valid due to application controller sync timeout`, Argo CD is trying to apply Keycloak custom resources before the operator finishes installing its CRDs. Longer timeouts do not help because the resources remain invalid until the CRDs appear. Follow the runbook in [`docs/troubleshooting/iam-sync-timeout.md`](docs/troubleshooting/iam-sync-timeout.md) to gather the relevant controller state and apply the sync-wave fix so the Keycloak operator finishes before the IAM stack reconciles.
 
+### Troubleshooting: ingress-nginx webhook TLS errors
+
+If the platform-addons application fails with `failed calling webhook "validate.nginx.ingress.kubernetes.io"` and the error mentions `x509: certificate signed by unknown authority`, the ingress-nginx admission webhook is serving a certificate that the Kubernetes API server does not trust yet. Cert-manager now manages the webhook certificates for us; ensure the platform-addons application has synced the updated ingress-nginx values and follow the steps in [`docs/troubleshooting/ingress-nginx-webhook-cert.md`](docs/troubleshooting/ingress-nginx-webhook-cert.md) to confirm the Certificate resource is ready.
+
 ## 3. Publish demo ingress hostnames
 
 Run the workflow **“04 - Configure demo hosts”** after the bootstrap finishes. The job calls [`scripts/configure_demo_hosts.py`](scripts/configure_demo_hosts.py) to discover the ingress IP, updates [`gitops/apps/iam/params.env`](gitops/apps/iam/params.env) with fresh `nip.io` hostnames, commits the change and prints the URLs. Argo CD is exposed through an HTTP ingress (TLS terminates at the `argocd-server` service), so the generated Argo link intentionally uses `http://`.

--- a/docs/troubleshooting/ingress-nginx-webhook-cert.md
+++ b/docs/troubleshooting/ingress-nginx-webhook-cert.md
@@ -1,0 +1,21 @@
+# Troubleshooting: ingress-nginx webhook certificate failures
+
+When Argo CD applies an Ingress resource before the ingress-nginx admission webhook has a valid TLS certificate,
+Kubernetes rejects the request with an error similar to:
+
+```
+one or more objects failed to apply, reason: Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://ingress-nginx-controller-admission.ingress-nginx.svc:443/networking/v1/ingresses?timeout=10s": tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+This indicates that the webhook configuration does not yet contain a trusted CA bundle. The bootstrap job that ships with the
+Helm chart generates a temporary CA, but it can race with the first Argo CD sync and lead to repeated reconciliation failures.
+
+## Resolution
+
+The GitOps configuration now delegates certificate management to cert-manager. Make sure the `platform-addons/ingress-nginx`
+application has synced successfully after enabling the chart value `controller.admissionWebhooks.certManager.enabled=true`.
+Cert-manager provisions a valid CA and TLS certificate for the webhook and patches the associated `ValidatingWebhookConfiguration`
+so the API server can verify the TLS chain. Once the webhook is healthy, retry the failed Argo CD application sync.
+
+If the problem persists, inspect the cert-manager events in the `ingress-nginx` namespace to confirm that the admission
+certificate secret exists and that the associated Certificate resource reports `Ready`.

--- a/gitops/clusters/aks/apps/platform-charts.applicationset.yaml
+++ b/gitops/clusters/aks/apps/platform-charts.applicationset.yaml
@@ -32,6 +32,9 @@ spec:
             targetRevision: 4.13.2
             values:
               controller:
+                admissionWebhooks:
+                  certManager:
+                    enabled: true
                 service:
                   annotations:
                     service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /is-dynamic-lb-initialized


### PR DESCRIPTION
## Summary
- configure the ingress-nginx Helm release to source its admission webhook certificates from cert-manager
- document the ingress-nginx webhook TLS failure runbook and link it from the main troubleshooting guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d933766060832b832f5a483bcfdc41