### PR TITLE
Align CNPG managed roles with app secrets

### DIFF
--- a/gitops/apps/iam/cnpg/cluster.yaml
+++ b/gitops/apps/iam/cnpg/cluster.yaml
@@ -55,6 +55,7 @@ spec:
         connectionLimit: -1
         passwordSecret:
           name: keycloak-db-app
+          key: password
       - name: midpoint
         ensure: present
         login: true
@@ -62,3 +63,4 @@ spec:
         connectionLimit: -1
         passwordSecret:
           name: midpoint-db-app
+          key: password

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -16,8 +16,6 @@ spec:
       value: "true"
     - name: http-management-host
       value: "0.0.0.0"
-    - name: proxy-headers
-      value: xforwarded
     - name: cache
       value: local
   features:
@@ -27,6 +25,8 @@ spec:
     hostname: kc.98.64.116.233.nip.io
     strict: false
     strictBackchannel: false
+  proxy:
+    headers: xforwarded
   http:
     httpEnabled: true
 


### PR DESCRIPTION
## Summary
- ensure CloudNativePG managed roles reference the password key in the application secrets so CNPG keeps credentials in sync
- configure the Keycloak operator to use the proxy.headers field instead of an additional option

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d938f4849c832b84d5177f57fd88dd