### PR TITLE
Ensure bootstrap seeds iam-db-app secret for Keycloak

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -151,7 +151,7 @@ jobs:
             echo "Database credentials are required (POSTGRES_SUPERUSER_PASSWORD, KEYCLOAK_DB_PASSWORD, MIDPOINT_DB_PASSWORD)."
             exit 1
           fi
-          for secret in cnpg-superuser keycloak-db-app midpoint-db-app; do
+          for secret in cnpg-superuser keycloak-db-app iam-db-app midpoint-db-app; do
             kubectl -n "${NAMESPACE_IAM}" delete secret "${secret}" --ignore-not-found >/dev/null 2>&1 || true
           done
           kubectl -n "${NAMESPACE_IAM}" create secret generic cnpg-superuser \
@@ -159,9 +159,9 @@ jobs:
             --from-literal=username=postgres \
             --from-literal=password="${POSTGRES_SUPERUSER_PASSWORD}" \
             --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n "${NAMESPACE_IAM}" create secret generic keycloak-db-app \
+          kubectl -n "${NAMESPACE_IAM}" create secret generic iam-db-app \
             --type=Opaque \
-            --from-literal=username=keycloak \
+            --from-literal=username=app \
             --from-literal=password="${KEYCLOAK_DB_PASSWORD}" \
             --dry-run=client -o yaml | kubectl apply -f -
           kubectl -n "${NAMESPACE_IAM}" create secret generic midpoint-db-app \


### PR DESCRIPTION
## Summary
- update the bootstrap workflow to recreate the CloudNativePG application secret as iam-db-app and seed it with the app role
- clean up the legacy keycloak-db-app secret so Argo CD cannot pick up stale credentials

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d956eb2c6c832bae13d231b22d64fb