### PR TITLE
Fix CNPG managed role password secret schema

### DIFF
--- a/gitops/apps/iam/cnpg/cluster.yaml
+++ b/gitops/apps/iam/cnpg/cluster.yaml
@@ -53,4 +53,3 @@ spec:
         connectionLimit: -1
         passwordSecret:
           name: midpoint-db-app
-          key: password


### PR DESCRIPTION
## Summary
- remove the unsupported key property from the CloudNativePG managed role passwordSecret
- rely on the default password key in the midpoint-db-app secret to satisfy the operator schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95bff50d4832b94b2f0c0f8b3fe97