### PR TITLE
Extend MidPoint rollout tolerances

### DIFF
--- a/gitops/apps/iam/midpoint/deployment.yaml
+++ b/gitops/apps/iam/midpoint/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: iam
 spec:
   replicas: 1
+  # MidPoint's first boot performs a sizeable schema bootstrap and application
+  # warm-up. Allow up to 30 minutes for the rollout before Kubernetes considers
+  # the deployment failed so that Argo CD does not flap during initial syncs.
+  progressDeadlineSeconds: 1800
   selector:
     matchLabels: { app: midpoint }
   template:
@@ -498,6 +502,14 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          startupProbe:
+            # MidPoint needs several minutes on cold starts while it imports
+            # bundles and populates the repository.  A TCP probe is sufficient
+            # to confirm the embedded web server is answering requests.
+            tcpSocket:
+              port: http
+            failureThreshold: 90 # ~15 minutes @ 10s period
+            periodSeconds: 10
           readinessProbe:
             # The midPoint UI login endpoint can take longer than the probe timeout to
             # answer while the application finishes bootstrapping, which was causing

--- a/gitops/apps/iam/midpoint/seeder-job.yaml
+++ b/gitops/apps/iam/midpoint/seeder-job.yaml
@@ -17,6 +17,10 @@ spec:
           env:
             - name: MIDPOINT_URL
               value: "http://midpoint:8080/midpoint"
+            - name: MIDPOINT_WAIT_MAX_ATTEMPTS
+              value: "90"
+            - name: MIDPOINT_WAIT_SLEEP_SECONDS
+              value: "10"
           volumeMounts:
             - name: objs
               mountPath: /objects


### PR DESCRIPTION
## Summary
- allow the MidPoint deployment up to 30 minutes to finish a rollout and add a startup probe so Kubernetes does not give up during long cold starts
- increase the MidPoint seeder job wait window so the REST importer keeps retrying while the application boots

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d96fddb408832bac7f109a7dd9f159