### PR TITLE
Fix IAM wait loop in bootstrap workflow

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -288,7 +288,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for attempt in $(seq 1 1); do
+          max_attempts=60
+          sleep_seconds=15
+          for attempt in $(seq 1 "${max_attempts}"); do
             sync=$(kubectl -n argocd get application iam -o jsonpath='{.status.sync.status}' 2>/dev/null || true)
             health=$(kubectl -n argocd get application iam -o jsonpath='{.status.health.status}' 2>/dev/null || true)
             phase=$(kubectl -n argocd get application iam -o jsonpath='{.status.operationState.phase}' 2>/dev/null || true)
@@ -302,7 +304,14 @@ jobs:
               echo "IAM application is synced and healthy"
               exit 0
             fi
-            if [ "${attempt}" -eq 1 ]; then
+            if [ "${phase}" = "Failed" ]; then
+              echo "IAM application sync failed"
+              echo '::group::IAM Argo CD application'
+              kubectl -n argocd get application iam -o yaml || true
+              echo '::endgroup::'
+              exit 1
+            fi
+            if [ "${attempt}" -eq "${max_attempts}" ]; then
               echo "Timed out waiting for IAM application to become healthy"
               echo '::group::IAM Argo CD application'
               kubectl -n argocd get application iam -o yaml || true
@@ -330,7 +339,7 @@ jobs:
               echo '::endgroup::'
               exit 1
             fi
-            sleep 10
+            sleep "${sleep_seconds}"
           done
 
       - name: Summary


### PR DESCRIPTION
## Summary
- allow the bootstrap workflow to poll the IAM Argo CD application for up to 15 minutes before giving up
- exit early with diagnostics if Argo CD marks the IAM sync as failed

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d97372975c832ba679933d26fd277f