### PR TITLE
Update demo host params to new ingress IP

### DIFF
--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.98.64.116.233.nip.io
-midpointHost=mp.98.64.116.233.nip.io
-argocdHost=argocd.98.64.116.233.nip.io
+keycloakHost=kc.132.164.46.57.nip.io
+midpointHost=mp.132.164.46.57.nip.io
+argocdHost=argocd.132.164.46.57.nip.io

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.98.64.116.233.nip.io
-midpointHost=mp.98.64.116.233.nip.io
-argocdHost=argocd.98.64.116.233.nip.io
+keycloakHost=kc.132.164.46.57.nip.io
+midpointHost=mp.132.164.46.57.nip.io
+argocdHost=argocd.132.164.46.57.nip.io


### PR DESCRIPTION
## Summary
- update the IAM demo params to use the 132.164.46.57 nip.io hosts
- keep the bootstrap params file aligned with the main IAM params

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d978a1ad2c832ba2b0beff59c6f704