### PR TITLE
Update ingress hostnames for new demo IP

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -22,7 +22,7 @@ spec:
     enabled:
       - token-exchange
   hostname:
-    hostname: kc.98.64.116.233.nip.io
+    hostname: kc.132.164.46.57.nip.io
     strict: false
     strictBackchannel: false
   proxy:

--- a/gitops/apps/iam/midpoint/ingress.yaml
+++ b/gitops/apps/iam/midpoint/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: mp.127.0.0.1.nip.io
+    - host: mp.132.164.46.57.nip.io
       http:
         paths:
           - path: /

--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.98.64.116.233.nip.io
-midpointHost=mp.98.64.116.233.nip.io
-argocdHost=argocd.98.64.116.233.nip.io
+keycloakHost=kc.132.164.46.57.nip.io
+midpointHost=mp.132.164.46.57.nip.io
+argocdHost=argocd.132.164.46.57.nip.io

--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: argocd.127.0.0.1.nip.io
+    - host: argocd.132.164.46.57.nip.io
       http:
         paths:
           - path: /

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.98.64.116.233.nip.io
-midpointHost=mp.98.64.116.233.nip.io
-argocdHost=argocd.98.64.116.233.nip.io
+keycloakHost=kc.132.164.46.57.nip.io
+midpointHost=mp.132.164.46.57.nip.io
+argocdHost=argocd.132.164.46.57.nip.io


### PR DESCRIPTION
## Summary
- update the IAM demo hostnames to use the 132.164.46.57 nip.io addresses
- align the Keycloak CR and bootstrap ingress definitions with the new hostname

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d978a1ad2c832ba2b0beff59c6f704