### PR TITLE
Trim whitespace from MidPoint DB secret files

### DIFF
--- a/gitops/apps/iam/midpoint/deployment.yaml
+++ b/gitops/apps/iam/midpoint/deployment.yaml
@@ -192,7 +192,11 @@ spec:
                   return 1
                 fi
 
-                cat "${file_path}"
+                # Kubernetes secrets created via `stringData` and `literals` often
+                # include a trailing newline when projected to files. Trim common
+                # line terminators so database authentication does not fail because
+                # of invisible whitespace.
+                tr -d '\r\n' <"${file_path}"
               }
 
               parse_positive_int() {


### PR DESCRIPTION
## Summary
- trim carriage returns and newlines when reading database credentials in the MidPoint init container
- document the trimming behavior to explain why it prevents connection failures caused by trailing whitespace

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d97c12482c832b9fdb7cc50f32f2d2