### PR TITLE
Keep midPoint repository credentials in env config

### DIFF
--- a/gitops/apps/iam/midpoint/kustomization.yaml
+++ b/gitops/apps/iam/midpoint/kustomization.yaml
@@ -11,6 +11,19 @@ configMapGenerator:
   - name: midpoint-config
     files: [config.xml]
   - name: midpoint-env
-    literals: [MP_NO_ENV_COMPAT=1, MP_UNSET_midpoint_repository_database=1, MP_UNSET_midpoint_repository_jdbcUrl=1, MP_UNSET_midpoint_repository_hibernateHbm2ddl=1, MP_UNSET_midpoint_repository_initializationFailTimeout=1, MP_UNSET_midpoint_repository_missingSchemaAction=1, MP_UNSET_midpoint_repository_upgradeableSchemaAction=1, MP_UNSET_midpoint_repository_jdbcUsername=1, MP_UNSET_midpoint_repository_jdbcPassword=1, MP_UNSET_midpoint_repository_username=1, MP_UNSET_midpoint_repository_password=1, MP_UNSET_midpoint_administrator_initialPassword_FILE=1, MP_UNSET_midpoint_administrator_userId_FILE=1, MIDPOINT_DB_HOST=iam-db-rw.iam.svc.cluster.local, MIDPOINT_DB_PORT=5432, MIDPOINT_DB_NAME=midpoint, MIDPOINT_DB_WAIT_MAX_ATTEMPTS=60, MIDPOINT_DB_WAIT_SLEEP_SECONDS=5]
+    literals:
+      - MP_NO_ENV_COMPAT=1
+      - MP_UNSET_midpoint_repository_database=1
+      - MP_UNSET_midpoint_repository_hibernateHbm2ddl=1
+      - MP_UNSET_midpoint_repository_initializationFailTimeout=1
+      - MP_UNSET_midpoint_repository_missingSchemaAction=1
+      - MP_UNSET_midpoint_repository_upgradeableSchemaAction=1
+      - MP_UNSET_midpoint_administrator_initialPassword_FILE=1
+      - MP_UNSET_midpoint_administrator_userId_FILE=1
+      - MIDPOINT_DB_HOST=iam-db-rw.iam.svc.cluster.local
+      - MIDPOINT_DB_PORT=5432
+      - MIDPOINT_DB_NAME=midpoint
+      - MIDPOINT_DB_WAIT_MAX_ATTEMPTS=60
+      - MIDPOINT_DB_WAIT_SLEEP_SECONDS=5
   - name: midpoint-objects
     files: [objects/01_org_rws.xml, objects/02_role_project_admin.xml, objects/03_org_architects.xml, objects/04_user_director.xml, objects/05_user_architect1.xml, objects/06_user_po1.xml, objects/07_user_dev1.xml]


### PR DESCRIPTION
## Summary
- stop unsetting midPoint repository JDBC credentials so the init container keeps the rendered values
- expand the midpoint-env literals for readability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d97c12482c832b9fdb7cc50f32f2d2