### PR TITLE
Ensure MidPoint config enforces TLS for database connections

### DIFF
--- a/gitops/apps/iam/midpoint/kustomization.yaml
+++ b/gitops/apps/iam/midpoint/kustomization.yaml
@@ -23,6 +23,7 @@ configMapGenerator:
       - MIDPOINT_DB_HOST=iam-db-rw.iam.svc.cluster.local
       - MIDPOINT_DB_PORT=5432
       - MIDPOINT_DB_NAME=midpoint
+      - MIDPOINT_DB_SSLMODE=require
       - MIDPOINT_DB_WAIT_MAX_ATTEMPTS=60
       - MIDPOINT_DB_WAIT_SLEEP_SECONDS=5
   - name: midpoint-objects


### PR DESCRIPTION
## Summary
- add the missing MIDPOINT_DB_SSLMODE literal so MidPoint requires TLS when connecting to the database

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d98045c580832bbc5977c12ddc8885