### PR TITLE
Ensure Keycloak ingress host is configured

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -40,6 +40,7 @@ spec:
   ingress:
     enabled: true
     className: nginx
+    hostname: kc.132.164.46.57.nip.io
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -42,6 +42,7 @@ replacements:
           name: rws-keycloak
         fieldPaths:
           - spec.hostname.hostname
+          - spec.ingress.hostname
   - source:
       kind: ConfigMap
       name: iam-ingress-settings


### PR DESCRIPTION
## Summary
- set the Keycloak custom resource to publish an explicit ingress hostname
- update kustomize replacements so the ingress hostname follows the shared params configmap

## Testing
- not run (kustomize CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d98226bea0832baaae9ce854f0070b