### PR TITLE
Configure Keycloak for edge proxy headers

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -18,6 +18,10 @@ spec:
       value: "0.0.0.0"
     - name: cache
       value: local
+    - name: proxy
+      value: edge
+    - name: proxy-headers
+      value: xforwarded
   features:
     enabled:
       - token-exchange


### PR DESCRIPTION
## Summary
- configure Keycloak to honour edge proxy headers injected by ingress controllers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98fd6682c832ba6a92948ecd1289c