### PR TITLE
Remove deprecated Keycloak ingress hostname field

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -44,7 +44,6 @@ spec:
   ingress:
     enabled: true
     className: nginx
-    hostname: kc.132.164.46.57.nip.io
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -42,7 +42,6 @@ replacements:
           name: rws-keycloak
         fieldPaths:
           - spec.hostname.hostname
-          - spec.ingress.hostname
   - source:
       kind: ConfigMap
       name: iam-ingress-settings


### PR DESCRIPTION
## Summary
- drop the unsupported `spec.ingress.hostname` attribute from the Keycloak custom resource
- update the IAM kustomization replacements to stop referencing the removed field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9952a1fe0832bb7c5c4fae5e26280