### PR TITLE
Update nip.io hosts to current ingress IP

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -26,7 +26,7 @@ spec:
     enabled:
       - token-exchange
   hostname:
-    hostname: kc.20.31.174.146.nip.io
+    hostname: kc.57.153.96.188.nip.io
     strict: false
     strictBackchannel: false
   proxy:

--- a/gitops/apps/iam/midpoint/ingress.yaml
+++ b/gitops/apps/iam/midpoint/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: mp.20.31.174.146.nip.io
+    - host: mp.57.153.96.188.nip.io
       http:
         paths:
           - path: /

--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.20.31.174.146.nip.io
-midpointHost=mp.20.31.174.146.nip.io
-argocdHost=argocd.20.31.174.146.nip.io
+keycloakHost=kc.57.153.96.188.nip.io
+midpointHost=mp.57.153.96.188.nip.io
+argocdHost=argocd.57.153.96.188.nip.io

--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: argocd.20.31.174.146.nip.io
+    - host: argocd.57.153.96.188.nip.io
       http:
         paths:
           - path: /

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.20.31.174.146.nip.io
-midpointHost=mp.20.31.174.146.nip.io
-argocdHost=argocd.20.31.174.146.nip.io
+keycloakHost=kc.57.153.96.188.nip.io
+midpointHost=mp.57.153.96.188.nip.io
+argocdHost=argocd.57.153.96.188.nip.io


### PR DESCRIPTION
## Summary
- update GitOps params and ingress manifests to point to the new 57.153.96.188 nip.io hostnames

## Testing
- pytest tests/test_configure_demo_hosts.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd21cfca0832bb1f50902e54e0579