### PR TITLE
Update nip.io hosts to 57.153.96.188

### DIFF
--- a/.github/workflows/03_configure_demo_hosts.yml
+++ b/.github/workflows/03_configure_demo_hosts.yml
@@ -137,12 +137,12 @@ jobs:
           MP_HOST_VALUE="${MP_HOST:-}"
           ARGOCD_HOST_VALUE="${ARGOCD_HOST:-}"
           BRANCH_REF="${GITHUB_REF:-}"
-          if git diff --quiet --exit-code -- gitops/apps/iam/params.env; then
+          if git diff --quiet --exit-code; then
             echo "Ingress host parameters already up to date; skipping commit."
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add gitops/apps/iam/params.env
+            git add --update
             git commit -m "Update demo ingress hosts to ${KC_HOST_VALUE}, ${MP_HOST_VALUE}, and ${ARGOCD_HOST_VALUE}"
             if [[ "${BRANCH_REF}" == refs/heads/* ]]; then
               BRANCH_NAME="${BRANCH_REF#refs/heads/}"

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -26,7 +26,7 @@ spec:
     enabled:
       - token-exchange
   hostname:
-    hostname: kc.20.31.174.146.nip.io
+    hostname: kc.57.153.96.188.nip.io
     strict: false
     strictBackchannel: false
   proxy:

--- a/gitops/apps/iam/midpoint/ingress.yaml
+++ b/gitops/apps/iam/midpoint/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: mp.20.31.174.146.nip.io
+    - host: mp.57.153.96.188.nip.io
       http:
         paths:
           - path: /

--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.20.31.174.146.nip.io
-midpointHost=mp.20.31.174.146.nip.io
-argocdHost=argocd.20.31.174.146.nip.io
+keycloakHost=kc.57.153.96.188.nip.io
+midpointHost=mp.57.153.96.188.nip.io
+argocdHost=argocd.57.153.96.188.nip.io

--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: argocd.20.31.174.146.nip.io
+    - host: argocd.57.153.96.188.nip.io
       http:
         paths:
           - path: /

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.20.31.174.146.nip.io
-midpointHost=mp.20.31.174.146.nip.io
-argocdHost=argocd.20.31.174.146.nip.io
+keycloakHost=kc.57.153.96.188.nip.io
+midpointHost=mp.57.153.96.188.nip.io
+argocdHost=argocd.57.153.96.188.nip.io


### PR DESCRIPTION
## Summary
- rotate the IAM demo nip.io hostnames to 57.153.96.188 in params files and manifests
- update the demo host workflow to stage all tracked changes so manifest updates are committed automatically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbd21cfca0832bb1f50902e54e0579