### PR TITLE
Fix ensure_ingress_load_balancer import path for direct execution

### DIFF
--- a/scripts/ensure_ingress_load_balancer.py
+++ b/scripts/ensure_ingress_load_balancer.py
@@ -11,6 +11,14 @@ import sys
 import time
 from dataclasses import dataclass
 from typing import Iterable, Optional
+from pathlib import Path
+
+if __package__ in (None, ""):
+    # Allow running the script directly via ``python scripts/<name>.py`` by ensuring the
+    # repository root (which contains the ``scripts`` package) is on ``sys.path``.
+    repo_root = Path(__file__).resolve().parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
 
 from scripts.configure_demo_hosts import DEFAULT_SERVICE, KubectlError, run_kubectl_jsonpath
 


### PR DESCRIPTION
## Summary
- ensure the scripts package is importable when executing ensure_ingress_load_balancer.py directly
- document repository root path injection for standalone execution

## Testing
- python scripts/ensure_ingress_load_balancer.py --help

------
https://chatgpt.com/codex/tasks/task_e_68dbda942220832b9fa15ba02ba5559a