### PR TITLE
Point midpoint deployment at dedicated database secret

### DIFF
--- a/gitops/apps/iam/midpoint/deployment.yaml
+++ b/gitops/apps/iam/midpoint/deployment.yaml
@@ -61,8 +61,8 @@ spec:
               port="${MIDPOINT_DB_PORT:-5432}"
               database="${MIDPOINT_DB_NAME:-midpoint}"
               sslmode="${MIDPOINT_DB_SSLMODE:-require}"
-              username_file="${MIDPOINT_DB_USERNAME_FILE:-/var/run/secrets/iam-db-app/username}"
-              password_file="${MIDPOINT_DB_PASSWORD_FILE:-/var/run/secrets/iam-db-app/password}"
+              username_file="${MIDPOINT_DB_USERNAME_FILE:-/var/run/secrets/midpoint-db/username}"
+              password_file="${MIDPOINT_DB_PASSWORD_FILE:-/var/run/secrets/midpoint-db/password}"
 
               max_attempts="$(parse_positive_int "${MIDPOINT_DB_WAIT_MAX_ATTEMPTS:-60}" 60)"
               sleep_seconds="$(parse_positive_int "${MIDPOINT_DB_WAIT_SLEEP_SECONDS:-5}" 5)"
@@ -124,12 +124,12 @@ spec:
                 name: midpoint-env
           env:
             - name: MIDPOINT_DB_USERNAME_FILE
-              value: /var/run/secrets/iam-db-app/username
+              value: /var/run/secrets/midpoint-db/username
             - name: MIDPOINT_DB_PASSWORD_FILE
-              value: /var/run/secrets/iam-db-app/password
+              value: /var/run/secrets/midpoint-db/password
           volumeMounts:
-            - name: iam-db-credentials
-              mountPath: /var/run/secrets/iam-db-app
+            - name: midpoint-db-credentials
+              mountPath: /var/run/secrets/midpoint-db
               readOnly: true
         - name: repo-init
           image: evolveum/midpoint:4.9-alpine
@@ -147,17 +147,17 @@ spec:
             - name: MP_SET_midpoint_repository_jdbcUrl
               valueFrom:
                 secretKeyRef:
-                  name: iam-db-app
+                  name: midpoint-db
                   key: jdbc-uri
             - name: MP_SET_midpoint_repository_jdbcUsername
               valueFrom:
                 secretKeyRef:
-                  name: iam-db-app
+                  name: midpoint-db
                   key: username
             - name: MP_SET_midpoint_repository_jdbcPassword
               valueFrom:
                 secretKeyRef:
-                  name: iam-db-app
+                  name: midpoint-db
                   key: password
             - name: MP_SET_midpoint_repository_missingSchemaAction
               value: "create"
@@ -253,8 +253,8 @@ spec:
                 exit 1
               fi
 
-              db_username_file="${MIDPOINT_DB_USERNAME_FILE:-/var/run/secrets/iam-db-app/username}"
-              db_password_file="${MIDPOINT_DB_PASSWORD_FILE:-/var/run/secrets/iam-db-app/password}"
+              db_username_file="${MIDPOINT_DB_USERNAME_FILE:-/var/run/secrets/midpoint-db/username}"
+              db_password_file="${MIDPOINT_DB_PASSWORD_FILE:-/var/run/secrets/midpoint-db/password}"
 
               db_username="$(read_secret_file "${db_username_file}" 'repository username')"
               db_password="$(read_secret_file "${db_password_file}" 'repository password')"
@@ -523,19 +523,22 @@ spec:
                 name: midpoint-env
           env:
             - name: MIDPOINT_JDBC_URL
-              value: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=require
+              valueFrom:
+                secretKeyRef:
+                  name: midpoint-db
+                  key: jdbc-uri
             - name: MIDPOINT_DB_USERNAME_FILE
-              value: /var/run/secrets/iam-db-app/username
+              value: /var/run/secrets/midpoint-db/username
             - name: MIDPOINT_DB_PASSWORD_FILE
-              value: /var/run/secrets/iam-db-app/password
+              value: /var/run/secrets/midpoint-db/password
           volumeMounts:
             - name: midpoint-home
               mountPath: /opt/midpoint/var
             - name: config-xml
               mountPath: /config-template
               readOnly: true
-            - name: iam-db-credentials
-              mountPath: /var/run/secrets/iam-db-app
+            - name: midpoint-db-credentials
+              mountPath: /var/run/secrets/midpoint-db
               readOnly: true
       containers:
         - name: midpoint
@@ -585,17 +588,17 @@ spec:
             - name: MP_SET_midpoint_repository_jdbcUrl
               valueFrom:
                 secretKeyRef:
-                  name: iam-db-app
+                  name: midpoint-db
                   key: jdbc-uri
             - name: MP_SET_midpoint_repository_jdbcUsername
               valueFrom:
                 secretKeyRef:
-                  name: iam-db-app
+                  name: midpoint-db
                   key: username
             - name: MP_SET_midpoint_repository_jdbcPassword
               valueFrom:
                 secretKeyRef:
-                  name: iam-db-app
+                  name: midpoint-db
                   key: password
             - name: MP_SET_midpoint_repository_missingSchemaAction
               value: "create"
@@ -613,8 +616,8 @@ spec:
             - name: midpoint-admin-secret
               mountPath: /var/run/secrets/midpoint-admin
               readOnly: true
-            - name: iam-db-credentials
-              mountPath: /var/run/secrets/iam-db-app
+            - name: midpoint-db-credentials
+              mountPath: /var/run/secrets/midpoint-db
               readOnly: true
           resources:
             requests:
@@ -629,9 +632,9 @@ spec:
         - name: config-xml
           configMap:
             name: midpoint-config
-        - name: iam-db-credentials
+        - name: midpoint-db-credentials
           secret:
-            secretName: iam-db-app
+            secretName: midpoint-db
         - name: midpoint-admin-secret
           secret:
             secretName: midpoint-admin

--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: iam
 
+resources:
+  - ../../../../k8s/iam/midpoint-db-secret.yaml
+
 generatorOptions:
   disableNameSuffixHash: true
   annotations:

--- a/k8s/iam/midpoint-db-secret.yaml
+++ b/k8s/iam/midpoint-db-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: midpoint-db
+  namespace: iam
+type: Opaque
+stringData:
+  jdbc-uri: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=require
+  username: midpoint
+  password: midpoint123!


### PR DESCRIPTION
## Summary
- add a committed midpoint-db secret manifest with the JDBC URI and credentials
- include the new secret in the IAM secrets kustomization so Argo CD reconciles it
- update the midpoint deployment to source JDBC settings and mounts from midpoint-db

## Testing
- not run (kustomize not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbe97ad7cc832ba70ec6bcf8a3a00b