### PR TITLE
Update demo ingress hostnames to new external IP

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -26,7 +26,7 @@ spec:
     enabled:
       - token-exchange
   hostname:
-    hostname: kc.57.153.96.188.nip.io
+    hostname: kc.20.76.98.154.nip.io
     strict: false
     strictBackchannel: false
   proxy:

--- a/gitops/apps/iam/midpoint/ingress.yaml
+++ b/gitops/apps/iam/midpoint/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: mp.57.153.96.188.nip.io
+    - host: mp.20.76.98.154.nip.io
       http:
         paths:
           - path: /

--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=
-midpointHost=
-argocdHost=
+keycloakHost=kc.20.76.98.154.nip.io
+midpointHost=mp.20.76.98.154.nip.io
+argocdHost=argocd.20.76.98.154.nip.io

--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: argocd.57.153.96.188.nip.io
+    - host: argocd.20.76.98.154.nip.io
       http:
         paths:
           - path: /

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.57.153.96.188.nip.io
-midpointHost=mp.57.153.96.188.nip.io
-argocdHost=argocd.57.153.96.188.nip.io
+keycloakHost=kc.20.76.98.154.nip.io
+midpointHost=mp.20.76.98.154.nip.io
+argocdHost=argocd.20.76.98.154.nip.io


### PR DESCRIPTION
## Summary
- update Keycloak, MidPoint, and Argo CD ingress resources to point at the new 20.76.98.154 nip.io address
- align the IAM params files so the bootstrap and app overlays reference the same hostnames

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf22b76c8832b9cc6d04b48e78d24