### PR TITLE
Fix Keycloak ingress host configuration

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -44,6 +44,8 @@ spec:
   ingress:
     enabled: true
     className: nginx
+    hostname: kc.20.76.98.154.nip.io
+    path: /
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -41,6 +41,7 @@ replacements:
           kind: Keycloak
           name: rws-keycloak
         fieldPaths:
+          - spec.ingress.hostname
           - spec.hostname.hostname
   - source:
       kind: ConfigMap


### PR DESCRIPTION
## Summary
- declare the Keycloak ingress hostname explicitly to avoid the default wildcard route
- propagate the configured host into the ingress stanza via kustomize replacements so rendered manifests stay consistent

## Testing
- not run (kustomize not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbf47e7314832bbb1d1c2ec9ae72b6