### PR TITLE
Handle missing skip reachability arg

### DIFF
--- a/scripts/configure_demo_hosts.py
+++ b/scripts/configure_demo_hosts.py
@@ -276,7 +276,7 @@ def main() -> int:
     ip_value = resolve_ingress_ip(args.ingress_service, args.ingress_ip, args.ingress_hostname)
     ensure_ingress_accessible(
         ip_value,
-        raise_on_error=not args.skip_reachability_check,
+        raise_on_error=not getattr(args, "skip_reachability_check", False),
     )
     hosts = build_hosts(ip_value)
 


### PR DESCRIPTION
## Summary
- guard access to the skip reachability flag when invoking ensure_ingress_accessible so it defaults to False when absent

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68dbf948e694832bb99b0057a6556840