### PR TITLE
Skip ingress reachability check during setup

### DIFF
--- a/.github/workflows/03_configure_demo_hosts.yml
+++ b/.github/workflows/03_configure_demo_hosts.yml
@@ -54,7 +54,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 scripts/configure_demo_hosts.py --params-file gitops/apps/iam/params.env
+          python3 scripts/configure_demo_hosts.py \
+            --params-file gitops/apps/iam/params.env \
+            --skip-reachability-check
 
       - name: Wait for ingress endpoints to become reachable
         shell: bash


### PR DESCRIPTION
## Summary
- ensure the configure demo hosts workflow passes the skip reachability check flag so the setup action no longer blocks on load balancer access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbfc9ec4c4832ba86082664b200e55