### PR TITLE
Fix Azure ingress controller health probe path

### DIFF
--- a/docs/troubleshooting/ingress-nginx-lb-healthcheck.md
+++ b/docs/troubleshooting/ingress-nginx-lb-healthcheck.md
@@ -1,0 +1,22 @@
+# Ingress controller reports no external connectivity
+
+When the `ingress-nginx` load balancer publishes an IP address but the hosts such as
+`kc.<ip>.nip.io` or `argocd.<ip>.nip.io` time out, check the Azure load-balancer
+health probe settings. If the probe hits a path that does not return HTTP 200 the
+platform will consider every backend node unhealthy and traffic will never reach the
+controller pods.
+
+The chart configuration previously pointed the probe at `/is-dynamic-lb-initialized`,
+a path that the controller does not expose. Standard probes would therefore fail and
+the public IP would accept connections but immediately reset them.
+
+Update the annotation to the controller's built-in health endpoint, `/healthz`:
+
+```yaml
+service:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+```
+
+After the change syncs, the probe begins reporting healthy and ingress hosts start
+responding to HTTP requests.

--- a/gitops/clusters/aks/apps/platform-charts.applicationset.yaml
+++ b/gitops/clusters/aks/apps/platform-charts.applicationset.yaml
@@ -37,7 +37,7 @@ spec:
                     enabled: true
                 service:
                   annotations:
-                    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /is-dynamic-lb-initialized
+                    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
                   type: LoadBalancer
                 watchIngressWithoutClass: true
                 ingressClassResource:


### PR DESCRIPTION
## Summary
- point the Azure load balancer health probe at the ingress controller /healthz endpoint so it registers the backends as healthy
- document the failure mode where an incorrect probe path leaves the ingress IP unreachable

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbfdd3d1fc832b9da8d2759f63b7fb