### PR TITLE
Use namespace-local CNPG service hostnames

### DIFF
--- a/docs/troubleshooting/keycloak-health-degraded.md
+++ b/docs/troubleshooting/keycloak-health-degraded.md
@@ -66,7 +66,7 @@ For more examples of response payloads, consult the [Keycloak health documentati
 
      kubectl -n iam run -it --rm pgclient \
        --image=ghcr.io/cloudnative-pg/postgresql:16.4 -- \
-       bash -lc "export PGPASSWORD='$PASS'; psql -h iam-db-rw.iam.svc.cluster.local -U '$USER' -d keycloak -c '\\conninfo'"
+      bash -lc "export PGPASSWORD='$PASS'; psql -h iam-db-rw -U '$USER' -d keycloak -c '\\conninfo'"
      ```
   3. If the command returns `\conninfo` without an error, the credentials are correct; otherwise update either the database user or the secret so that they match.
 * **TLS enforcement errors:** If the readiness payload or Keycloak logs mention `SSL off` or a missing `pg_hba.conf` entry, confirm the `Keycloak` manifest still declares `spec.db.urlProperties: "?sslmode=require"`. The operator concatenates that value onto the JDBC URL; omitting the leading `?` produces a database name such as `keycloaksslmode=require`, which fails with `FATAL: database "keycloaksslmode=require" does not exist`. Keeping the delimiter ensures every connection negotiates TLS when CloudNativePG requires encryption.

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -36,7 +36,7 @@ spec:
 
   db:
     vendor: postgres
-    url: "jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require"
+    url: "jdbc:postgresql://iam-db-rw:5432/keycloak?sslmode=require"
     schema: public
     usernameSecret: { name: iam-db-app, key: username }
     passwordSecret: { name: iam-db-app, key: password }

--- a/gitops/apps/iam/midpoint/deployment.yaml
+++ b/gitops/apps/iam/midpoint/deployment.yaml
@@ -57,7 +57,7 @@ spec:
                 fi
               }
 
-              host="${MIDPOINT_DB_HOST:-iam-db-rw.iam.svc.cluster.local}"
+              host="${MIDPOINT_DB_HOST:-iam-db-rw}"
               port="${MIDPOINT_DB_PORT:-5432}"
               database="${MIDPOINT_DB_NAME:-midpoint}"
               sslmode="${MIDPOINT_DB_SSLMODE:-require}"

--- a/gitops/apps/iam/midpoint/kustomization.yaml
+++ b/gitops/apps/iam/midpoint/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
       - MP_UNSET_midpoint_repository_upgradeableSchemaAction=1
       - MP_UNSET_midpoint_administrator_initialPassword_FILE=1
       - MP_UNSET_midpoint_administrator_userId_FILE=1
-      - MIDPOINT_DB_HOST=iam-db-rw.iam.svc.cluster.local
+      - MIDPOINT_DB_HOST=iam-db-rw
       - MIDPOINT_DB_PORT=5432
       - MIDPOINT_DB_NAME=midpoint
       - MIDPOINT_DB_SSLMODE=require

--- a/k8s/iam/midpoint-db-secret.yaml
+++ b/k8s/iam/midpoint-db-secret.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: iam
 type: Opaque
 stringData:
-  jdbc-uri: jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/midpoint?sslmode=require
+  jdbc-uri: jdbc:postgresql://iam-db-rw:5432/midpoint?sslmode=require
   username: midpoint
   password: midpoint123!


### PR DESCRIPTION
## Summary
- update Keycloak and MidPoint database URLs to use the short CNPG service hostname
- align MidPoint manifests and troubleshooting docs with the new hostname to avoid DNS resolution issues

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc027e72f4832b819b5da6693c2fcc