### PR TITLE
Fix Argo CD admin login loop over HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ controller logs, inspect the `/health/ready` payload and resolve the underlying 
 
 When the IAM application reports `one or more synchronization tasks are not valid due to application controller sync timeout`, Argo CD is trying to apply Keycloak custom resources before the operator finishes installing its CRDs. Longer timeouts do not help because the resources remain invalid until the CRDs appear. Follow the runbook in [`docs/troubleshooting/iam-sync-timeout.md`](docs/troubleshooting/iam-sync-timeout.md) to gather the relevant controller state and apply the sync-wave fix so the Keycloak operator finishes before the IAM stack reconciles.
 
+If the Argo CD UI immediately returns you to the login page even with the correct `admin` password, apply the workaround in [`docs/troubleshooting/argocd-login-loop.md`](docs/troubleshooting/argocd-login-loop.md). Argo CD 3.1 marks its session cookie as `Secure` by default; the patch teaches the bootstrap overlay to run the server in insecure mode so browsers keep the session when you access it over HTTP.
+
 ### Troubleshooting: ingress-nginx webhook TLS errors
 
 If the platform-addons application fails with `failed calling webhook "validate.nginx.ingress.kubernetes.io"` and the error mentions `x509: certificate signed by unknown authority`, the ingress-nginx admission webhook is serving a certificate that the Kubernetes API server does not trust yet. Cert-manager now manages the webhook certificates for us; ensure the platform-addons application has synced the updated ingress-nginx values and follow the steps in [`docs/troubleshooting/ingress-nginx-webhook-cert.md`](docs/troubleshooting/ingress-nginx-webhook-cert.md) to confirm the Certificate resource is ready.

--- a/docs/troubleshooting/argocd-login-loop.md
+++ b/docs/troubleshooting/argocd-login-loop.md
@@ -1,0 +1,22 @@
+# Argo CD admin login loops back to the sign-in page
+
+## Symptoms
+- Signing in to the Argo CD UI with the `admin` username and the password from `argocd-initial-admin-secret` briefly flashes the loading spinner and immediately returns to the login screen.
+- Browser developer tools show that the `argocd.token` cookie is never persisted when you authenticate through `http://`.
+
+## Root cause
+The upstream Argo CD manifest enables TLS on the `argocd-server` pod and sets the `Secure` attribute on the session cookie. Our ingress presents Argo CD over plain HTTP (TLS terminates at the Kubernetes service), so browsers drop the secure cookie and you are bounced back to the login page.
+
+## Fix
+1. Patch the `argocd-cmd-params-cm` ConfigMap so the server runs in insecure mode and stops marking the cookie as `Secure`:
+   ```sh
+   kubectl -n argocd patch configmap argocd-cmd-params-cm \
+     --type merge \
+     -p '{"data":{"server.insecure":"true"}}'
+   kubectl -n argocd rollout restart deploy argocd-server
+   ```
+2. Wait for the rollout to complete (`kubectl -n argocd get pods`).
+3. Refresh the Argo CD UI and sign in again with the same credentials. The login now sticks because the cookie can be stored over HTTP.
+
+## Long-term remediation
+This repository now includes the patch in `gitops/clusters/aks/bootstrap/argocd-cmd-params-cm-patch.yaml`. Re-run the **“02 - Bootstrap Argo CD”** workflow (or `kubectl apply -k gitops/clusters/aks/bootstrap`) so future clusters automatically set `server.insecure: "true"` during bootstrap.

--- a/gitops/clusters/aks/bootstrap/argocd-cmd-params-cm-patch.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-cmd-params-cm-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  labels:
+    app.kubernetes.io/name: argocd-cmd-params-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  server.insecure: "true"

--- a/gitops/clusters/aks/bootstrap/kustomization.yaml
+++ b/gitops/clusters/aks/bootstrap/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - argocd-ingress.yaml
 patches:
   - path: argocd-cm-patch.yaml
+  - path: argocd-cmd-params-cm-patch.yaml
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:


### PR DESCRIPTION
## Summary
- ensure the bootstrap overlay patches argocd-cmd-params-cm with server.insecure so HTTP ingress works
- document the login loop symptom and link the runbook from the README

## Testing
- not run (documentation and manifest patch only)


------
https://chatgpt.com/codex/tasks/task_e_68dc0315fd8c832ba9cb76027bed00ec