### PR TITLE
Fix Keycloak ingress hostname schema mismatch

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -44,7 +44,6 @@ spec:
   ingress:
     enabled: true
     className: nginx
-    hostname: kc.20.76.98.154.nip.io
     path: /
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -41,7 +41,6 @@ replacements:
           kind: Keycloak
           name: rws-keycloak
         fieldPaths:
-          - spec.ingress.hostname
           - spec.hostname.hostname
   - source:
       kind: ConfigMap


### PR DESCRIPTION
## Summary
- remove the unsupported spec.ingress.hostname replacement from the IAM kustomization
- drop the spec.ingress.hostname field from the Keycloak manifest so it matches the CRD schema

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68dc0f7ffc9c832bb70e2b0f2f1e3a40