### PR TITLE
Ensure CloudNativePG manages Keycloak database role

### DIFF
--- a/gitops/apps/iam/cnpg/cluster.yaml
+++ b/gitops/apps/iam/cnpg/cluster.yaml
@@ -48,6 +48,11 @@ spec:
 
   managed:
     roles:
+      - name: app
+        ensure: present
+        login: true
+        inherit: true
+        connectionLimit: -1
       - name: midpoint
         ensure: present
         login: true


### PR DESCRIPTION
## Summary
- add a managed `app` role to the iam-db CloudNativePG cluster so Keycloak gets credentials from the operator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc21db7434832bb4f22aafc5258643