### PR TITLE
Delay Keycloak sync until after database deployment

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -3,6 +3,8 @@ kind: Keycloak
 metadata:
   name: rws-keycloak
   namespace: iam
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
 spec:
   image: quay.io/keycloak/keycloak:26.3.5
   instances: 1


### PR DESCRIPTION
## Summary
- add an Argo CD sync-wave annotation to the Keycloak CR so it waits for the CloudNativePG services before reconciling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc26f39c44832bacddb0bf15eb7b5b