### PR TITLE
Update ingress hosts to new external IP 132.164.56.132

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -28,7 +28,7 @@ spec:
     enabled:
       - token-exchange
   hostname:
-    hostname: kc.20.76.98.154.nip.io
+    hostname: kc.132.164.56.132.nip.io
     strict: false
     strictBackchannel: false
   proxy:

--- a/gitops/apps/iam/midpoint/ingress.yaml
+++ b/gitops/apps/iam/midpoint/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: mp.20.76.98.154.nip.io
+    - host: mp.132.164.56.132.nip.io
       http:
         paths:
           - path: /

--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.20.76.98.154.nip.io
-midpointHost=mp.20.76.98.154.nip.io
-argocdHost=argocd.20.76.98.154.nip.io
+keycloakHost=kc.132.164.56.132.nip.io
+midpointHost=mp.132.164.56.132.nip.io
+argocdHost=argocd.132.164.56.132.nip.io

--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: argocd.20.76.98.154.nip.io
+    - host: argocd.132.164.56.132.nip.io
       http:
         paths:
           - path: /

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.20.76.98.154.nip.io
-midpointHost=mp.20.76.98.154.nip.io
-argocdHost=argocd.20.76.98.154.nip.io
+keycloakHost=kc.132.164.56.132.nip.io
+midpointHost=mp.132.164.56.132.nip.io
+argocdHost=argocd.132.164.56.132.nip.io


### PR DESCRIPTION
## Summary
- update IAM ingress host parameters to use the new external IP 132.164.56.132
- update Keycloak, MidPoint, and Argo CD ingress manifests to reference the new hostname values

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68dc3c306b98832b90652a0b534b3fee