### PR TITLE
Fix Argo CD ingress service port when using HTTP backend

### DIFF
--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -18,4 +18,4 @@ spec:
               service:
                 name: argocd-server
                 port:
-                  name: https
+                  name: http

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -131,6 +131,12 @@ def test_bootstrap_ingress_replacements():
     assert has_replacement("data.ingressClass", "Ingress", "argocd-server", "spec.ingressClassName")
     assert has_replacement("data.argocdHost", "Ingress", "argocd-server", "spec.rules.0.host")
 
+    ingress = load_yaml(REPO_ROOT / "gitops/clusters/aks/bootstrap/argocd-ingress.yaml")
+    backend = (
+        ingress["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]
+    )
+    assert backend["port"].get("name") == "http"
+
 
 def test_iam_secret_generators_use_opaque_type():
     kustomization = yaml.safe_load(


### PR DESCRIPTION
## Summary
- point the bootstrap Argo CD ingress at the HTTP service port to match the insecure server mode
- extend the GitOps structure tests to assert the ingress backend uses the HTTP port

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc3eb6f620832b90e9b94214b30beb