### PR TITLE
Fix Keycloak ingress class configuration

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -45,7 +45,7 @@ spec:
 
   ingress:
     enabled: true
-    className: nginx
+    ingressClassName: nginx
     path: /
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -26,7 +26,7 @@ replacements:
           kind: Keycloak
           name: rws-keycloak
         fieldPaths:
-          - spec.ingress.className
+          - spec.ingress.ingressClassName
       - select:
           kind: Ingress
           name: midpoint

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -105,7 +105,7 @@ def test_iam_ingress_replacements_cover_all_targets():
                         return True
         return False
 
-    assert has_replacement("data.ingressClass", "Keycloak", "rws-keycloak", "spec.ingress.className")
+    assert has_replacement("data.ingressClass", "Keycloak", "rws-keycloak", "spec.ingress.ingressClassName")
     assert has_replacement("data.ingressClass", "Ingress", "midpoint", "spec.ingressClassName")
     assert has_replacement("data.keycloakHost", "Keycloak", "rws-keycloak", "spec.hostname.hostname")
     assert has_replacement("data.midpointHost", "Ingress", "midpoint", "spec.rules.0.host")


### PR DESCRIPTION
## Summary
- update the Keycloak custom resource to set the ingress class with the ingressClassName field
- align the IAM kustomization replacements and tests with the new field name

## Testing
- pytest tests/test_gitops_structure.py::test_iam_ingress_replacements_cover_all_targets -q

------
https://chatgpt.com/codex/tasks/task_e_68dc41827098832ba9d05ec6488fc554