### PR TITLE
Add explicit Keycloak ingress manifest

### DIFF
--- a/gitops/apps/iam/keycloak/ingress.yaml
+++ b/gitops/apps/iam/keycloak/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rws-keycloak
+  namespace: iam
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: kc.132.164.56.132.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rws-keycloak-service
+                port:
+                  name: http
+

--- a/gitops/apps/iam/keycloak/kustomization.yaml
+++ b/gitops/apps/iam/keycloak/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - keycloak.yaml
+  - ingress.yaml
   - rws-realm.yaml

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -29,6 +29,11 @@ replacements:
           - spec.ingress.ingressClassName
       - select:
           kind: Ingress
+          name: rws-keycloak
+        fieldPaths:
+          - spec.ingressClassName
+      - select:
+          kind: Ingress
           name: midpoint
         fieldPaths:
           - spec.ingressClassName
@@ -42,6 +47,11 @@ replacements:
           name: rws-keycloak
         fieldPaths:
           - spec.hostname.hostname
+      - select:
+          kind: Ingress
+          name: rws-keycloak
+        fieldPaths:
+          - spec.rules.0.host
   - source:
       kind: ConfigMap
       name: iam-ingress-settings

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -106,8 +106,10 @@ def test_iam_ingress_replacements_cover_all_targets():
         return False
 
     assert has_replacement("data.ingressClass", "Keycloak", "rws-keycloak", "spec.ingress.ingressClassName")
+    assert has_replacement("data.ingressClass", "Ingress", "rws-keycloak", "spec.ingressClassName")
     assert has_replacement("data.ingressClass", "Ingress", "midpoint", "spec.ingressClassName")
     assert has_replacement("data.keycloakHost", "Keycloak", "rws-keycloak", "spec.hostname.hostname")
+    assert has_replacement("data.keycloakHost", "Ingress", "rws-keycloak", "spec.rules.0.host")
     assert has_replacement("data.midpointHost", "Ingress", "midpoint", "spec.rules.0.host")
 
 


### PR DESCRIPTION
## Summary
- add an explicit Ingress manifest for the Keycloak service so the host is rendered from repo parameters
- extend the IAM kustomization replacements to configure the ingress class and host for the new resource
- update structure tests to require the new replacements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc4758bda8832b86b0dbd5f646dbd9