### PR TITLE
Fix Keycloak ingress pathType for NGINX routing

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -47,6 +47,7 @@ spec:
     enabled: true
     ingressClassName: nginx
     path: /
+    pathType: Prefix
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"


### PR DESCRIPTION
## Summary
- ensure the Keycloak ingress uses a Prefix pathType so NGINX matches subpaths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc47100c78832b87a3f00cb9f34344