### PR TITLE
Align Keycloak database secrets with CNPG managed roles

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -151,7 +151,7 @@ jobs:
             echo "Database credentials are required (POSTGRES_SUPERUSER_PASSWORD, KEYCLOAK_DB_PASSWORD, MIDPOINT_DB_PASSWORD)."
             exit 1
           fi
-          for secret in cnpg-superuser keycloak-db-app iam-db-app midpoint-db-app; do
+          for secret in cnpg-superuser keycloak-db-app midpoint-db-app; do
             kubectl -n "${NAMESPACE_IAM}" delete secret "${secret}" --ignore-not-found >/dev/null 2>&1 || true
           done
           kubectl -n "${NAMESPACE_IAM}" create secret generic cnpg-superuser \
@@ -159,9 +159,9 @@ jobs:
             --from-literal=username=postgres \
             --from-literal=password="${POSTGRES_SUPERUSER_PASSWORD}" \
             --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n "${NAMESPACE_IAM}" create secret generic iam-db-app \
+          kubectl -n "${NAMESPACE_IAM}" create secret generic keycloak-db-app \
             --type=Opaque \
-            --from-literal=username=app \
+            --from-literal=username=keycloak \
             --from-literal=password="${KEYCLOAK_DB_PASSWORD}" \
             --dry-run=client -o yaml | kubectl apply -f -
           kubectl -n "${NAMESPACE_IAM}" create secret generic midpoint-db-app \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Trigger the workflow **“01 - Provision AKS with Terraform”** (`.github/wor
    - Validate the GitOps manifests via the unit tests before touching the cluster.
    - Create the database and admin secrets in the `iam` namespace.
    - Configure Keycloak with the strongly typed database settings and keep `spec.db.urlProperties` prefixed with `?sslmode=require` so JDBC connections to the CloudNativePG primary always negotiate TLS and the readiness health check passes when encryption is mandatory.
-   - Source Keycloak's credentials directly from CloudNativePG's generated `iam-db-app` secret so the pod always uses the in-cluster password.
+   - Source Keycloak's credentials directly from CloudNativePG's managed `keycloak-db-app` secret so the pod always uses the in-cluster password.
    - Normalise the Azure Blob credentials into the `cnpg-azure-backup` secret using `scripts/normalize_azure_storage_secret.py`.
    - Apply the GitOps tree (`gitops/clusters/aks`) so Argo CD manages addons (cert-manager, CloudNativePG operator, ingress-nginx, Keycloak operator) and the IAM workloads (CloudNativePG cluster, Keycloak, midPoint).
    - Wait for all applications to report `Synced` and `Healthy`.

--- a/docs/troubleshooting/cnpg-database-outofsync.md
+++ b/docs/troubleshooting/cnpg-database-outofsync.md
@@ -66,7 +66,7 @@ Run these commands to validate the operator and the database status:
 kubectl -n cnpg-system get deploy,pods
 kubectl get crd | grep postgresql.cnpg.io
 kubectl -n iam get cluster
-kubectl -n iam get secret iam-db-app
+kubectl -n iam get secret keycloak-db-app
 kubectl -n iam describe database keycloak
 kubectl -n iam get database keycloak -o yaml | yq '.status'
 ```

--- a/docs/troubleshooting/keycloak-health-degraded.md
+++ b/docs/troubleshooting/keycloak-health-degraded.md
@@ -51,18 +51,18 @@ For more examples of response payloads, consult the [Keycloak health documentati
 
 ## Apply the fix
 
-* **Database connectivity:** Verify the CloudNativePG generated `iam-db-app` secret contains a working password for the `app` user. Keycloak now consumes that secret directly, so a mismatch indicates the database user was changed manually. To confirm the credentials quickly:
+* **Database connectivity:** Verify the CloudNativePG managed `keycloak-db-app` secret contains a working password for the `keycloak` role. Keycloak now consumes that secret directly, so a mismatch indicates the database user was changed manually. To confirm the credentials quickly:
   1. Decode the credentials that Keycloak consumes:
      ```bash
-     kubectl -n iam get secret iam-db-app \
+     kubectl -n iam get secret keycloak-db-app \
        -o jsonpath='{.data.username}' | base64 -d; echo
-     kubectl -n iam get secret iam-db-app \
+     kubectl -n iam get secret keycloak-db-app \
        -o jsonpath='{.data.password}' | base64 -d; echo
      ```
   2. Test those credentials against the CloudNativePG primary:
      ```bash
-     USER=$(kubectl -n iam get secret iam-db-app -o jsonpath='{.data.username}' | base64 -d)
-     PASS=$(kubectl -n iam get secret iam-db-app -o jsonpath='{.data.password}' | base64 -d)
+     USER=$(kubectl -n iam get secret keycloak-db-app -o jsonpath='{.data.username}' | base64 -d)
+     PASS=$(kubectl -n iam get secret keycloak-db-app -o jsonpath='{.data.password}' | base64 -d)
 
      kubectl -n iam run -it --rm pgclient \
        --image=ghcr.io/cloudnative-pg/postgresql:16.4 -- \

--- a/gitops/apps/iam/cnpg/cluster.yaml
+++ b/gitops/apps/iam/cnpg/cluster.yaml
@@ -15,7 +15,7 @@ spec:
   bootstrap:
     initdb:
       database: keycloak
-      owner: app
+      owner: keycloak
       encoding: UTF8
       localeCollate: C
       localeCType: C
@@ -49,13 +49,14 @@ spec:
 
   managed:
     roles:
-      - name: app
+      - name: keycloak
         ensure: present
         login: true
         inherit: true
         connectionLimit: -1
         passwordSecret:
-          name: iam-db-app
+          name: keycloak-db-app
+          key: password
       - name: midpoint
         ensure: present
         login: true
@@ -63,3 +64,4 @@ spec:
         connectionLimit: -1
         passwordSecret:
           name: midpoint-db-app
+          key: password

--- a/gitops/apps/iam/cnpg/database-keycloak.yaml
+++ b/gitops/apps/iam/cnpg/database-keycloak.yaml
@@ -10,7 +10,7 @@ spec:
   cluster:
     name: iam-db
   name: keycloak
-  owner: app
+  owner: keycloak
   schemas:
     - name: public
-      owner: app
+      owner: keycloak

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -22,8 +22,6 @@ spec:
       value: local
     - name: proxy
       value: edge
-    - name: proxy-headers
-      value: xforwarded
   features:
     enabled:
       - token-exchange
@@ -40,8 +38,8 @@ spec:
     vendor: postgres
     url: "jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require"
     schema: public
-    usernameSecret: { name: iam-db-app, key: username }
-    passwordSecret: { name: iam-db-app, key: password }
+    usernameSecret: { name: keycloak-db-app, key: username }
+    passwordSecret: { name: keycloak-db-app, key: password }
 
   ingress:
     enabled: true

--- a/gitops/apps/iam/secrets/kustomization.yaml
+++ b/gitops/apps/iam/secrets/kustomization.yaml
@@ -10,7 +10,7 @@ generatorOptions:
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
 
-# Keycloak consumes the CloudNativePG managed `iam-db-app` secret directly, so only
+# Keycloak consumes the CloudNativePG managed `keycloak-db-app` secret directly, so only
 # the MidPoint credentials remain declarative here.
 secretGenerator:
   - name: midpoint-db-app

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -174,13 +174,17 @@ def test_cnpg_cluster_handles_missing_crds_and_roles():
     def find_role(name: str):
         return next((role for role in roles if role.get("name") == name), None)
 
-    app_role = find_role("app")
-    assert app_role is not None, "app role should be managed for Keycloak"
-    assert app_role.get("passwordSecret", {}).get("name") == "iam-db-app"
+    keycloak_role = find_role("keycloak")
+    assert keycloak_role is not None, "keycloak role should be managed"
+    keycloak_secret = keycloak_role.get("passwordSecret", {})
+    assert keycloak_secret.get("name") == "keycloak-db-app"
+    assert keycloak_secret.get("key") == "password"
 
     midpoint_role = find_role("midpoint")
     assert midpoint_role is not None, "midpoint role should remain managed"
-    assert midpoint_role.get("passwordSecret", {}).get("name") == "midpoint-db-app"
+    midpoint_secret = midpoint_role.get("passwordSecret", {})
+    assert midpoint_secret.get("name") == "midpoint-db-app"
+    assert midpoint_secret.get("key") == "password"
 
 
 def test_cnpg_databases_skip_dry_run():


### PR DESCRIPTION
## Summary
- manage Keycloak and MidPoint database roles via the CNPG Cluster with application secrets as the password source
- update the Keycloak database CR, operator workflow, and docs to reference the keycloak-db-app secret
- drop legacy proxy header overrides from the Keycloak CR and extend tests for the new managed role contract

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc50af1b28832b86821e67ed1bd9ca