### PR TITLE
Add sync wave annotation to midPoint deployment

### DIFF
--- a/gitops/apps/iam/midpoint/deployment-argocd-sync-wave-patch.yaml
+++ b/gitops/apps/iam/midpoint/deployment-argocd-sync-wave-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: midpoint
+  namespace: iam
+  annotations:
+    argocd.argoproj.io/sync-wave: "40"

--- a/gitops/apps/iam/midpoint/kustomization.yaml
+++ b/gitops/apps/iam/midpoint/kustomization.yaml
@@ -4,6 +4,9 @@ namespace: iam
 
 resources: [deployment.yaml, ingress.yaml, seeder-job.yaml]
 
+patchesStrategicMerge:
+  - deployment-argocd-sync-wave-patch.yaml
+
 generatorOptions:
   disableNameSuffixHash: true
 


### PR DESCRIPTION
## Summary
- add a Kustomize patch that annotates the midPoint Deployment with Argo CD sync wave 40
- include the patch in the midPoint kustomization so the desired ordering is reconciled by GitOps

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc5be3cac4832bb5798ca66efe153f