### PR TITLE
Prevent IAM Keycloak sync from stalling on missing CRDs

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: iam
   annotations:
     argocd.argoproj.io/sync-wave: "30"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   image: quay.io/keycloak/keycloak:26.3.5
   instances: 1

--- a/gitops/apps/iam/keycloak/rws-realm.yaml
+++ b/gitops/apps/iam/keycloak/rws-realm.yaml
@@ -4,6 +4,8 @@ metadata:
   name: rws-realm-import
   namespace: iam
   annotations:
+    argocd.argoproj.io/sync-wave: "40"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     iam.demo/realm-config-version: "1"
 spec:
   keycloakCRName: rws-keycloak

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -195,3 +195,22 @@ def test_cnpg_databases_skip_dry_run():
             annotations.get("argocd.argoproj.io/sync-options")
             == "SkipDryRunOnMissingResource=true"
         ), f"{manifest_name} must skip dry-run until CNPG CRDs register"
+
+
+def test_keycloak_resources_skip_dry_run_and_wave_ordering():
+    keycloak = load_yaml(REPO_ROOT / "gitops/apps/iam/keycloak/keycloak.yaml")
+    keycloak_annotations = keycloak["metadata"].get("annotations", {})
+    assert (
+        keycloak_annotations.get("argocd.argoproj.io/sync-options")
+        == "SkipDryRunOnMissingResource=true"
+    ), "Keycloak CR should skip dry-run while CRDs install"
+
+    realm = load_yaml(REPO_ROOT / "gitops/apps/iam/keycloak/rws-realm.yaml")
+    realm_annotations = realm["metadata"].get("annotations", {})
+    assert (
+        realm_annotations.get("argocd.argoproj.io/sync-options")
+        == "SkipDryRunOnMissingResource=true"
+    ), "Realm import should skip dry-run while CRDs install"
+    assert (
+        realm_annotations.get("argocd.argoproj.io/sync-wave") == "40"
+    ), "Realm import should wait for the Keycloak instance to finish first"


### PR DESCRIPTION
## Summary
- add SkipDryRunOnMissingResource to the Keycloak CR so Argo CD no longer stalls while CRDs register
- ensure the Keycloak realm import runs in a later sync wave and skips dry-run until CRDs exist
- extend the GitOps structure tests to cover the new annotations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc60d1b05c832b83f4d46cfbb0a1fd