### PR TITLE
Improve midPoint seeder diagnostics when IAM app waits for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ controller logs, inspect the `/health/ready` payload and resolve the underlying 
 
 When the IAM application reports `one or more synchronization tasks are not valid due to application controller sync timeout`, Argo CD is trying to apply Keycloak custom resources before the operator finishes installing its CRDs. Longer timeouts do not help because the resources remain invalid until the CRDs appear. Follow the runbook in [`docs/troubleshooting/iam-sync-timeout.md`](docs/troubleshooting/iam-sync-timeout.md) to gather the relevant controller state and apply the sync-wave fix so the Keycloak operator finishes before the IAM stack reconciles.
 
+### Troubleshooting: IAM application waiting for resources
+
+If the IAM application stalls with a message like `waiting for resources`, the midPoint PostSync seeder job is still running. Inspect the seeder job and midPoint pods with [`scripts/collect_midpoint_diagnostics.sh`](scripts/collect_midpoint_diagnostics.sh) and follow [`docs/troubleshooting/iam-waiting-for-resources.md`](docs/troubleshooting/iam-waiting-for-resources.md) to resolve the underlying midPoint readiness or credential issue.
+
 If the Argo CD UI immediately returns you to the login page even with the correct `admin` password, apply the workaround in [`docs/troubleshooting/argocd-login-loop.md`](docs/troubleshooting/argocd-login-loop.md). Argo CD 3.1 marks its session cookie as `Secure` by default; the patch teaches the bootstrap overlay to run the server in insecure mode so browsers keep the session when you access it over HTTP.
 
 ### Troubleshooting: ingress-nginx webhook TLS errors

--- a/docs/troubleshooting/iam-waiting-for-resources.md
+++ b/docs/troubleshooting/iam-waiting-for-resources.md
@@ -1,0 +1,73 @@
+# IAM application stuck on `waiting for resources`
+
+## Symptoms
+
+* Argo CD shows the `iam` application with `phase=Running`, `sync=OutOfSync` or `sync=Synced` but the last
+  operation message reads `waiting for resources`.
+* The operation state lists the `batch/Job: midpoint-seeder` resource as pending or running for an extended
+  period of time.
+* `kubectl get jobs midpoint-seeder -n iam` reports the job as `Active`, and its logs repeat
+  `midPoint not ready yet (HTTP 503)` or similar messages.
+
+## Why this happens
+
+The IAM kustomization seeds demo objects into midPoint using a PostSync job. Argo CD waits for this job to
+finish before it can mark the application healthy. The job polls the midPoint REST endpoint until it receives
+an HTTP 200 response. When midPoint is unhealthy—because the pod is still starting, the database connection
+fails, or the administrator credentials are incorrect—the job keeps retrying and Argo CD keeps reporting
+`waiting for resources`.
+
+The seeder job now fails fast when the REST API returns HTTP 401/403 (invalid admin credentials) or HTTP 404
+(incorrect service URL). These errors typically point to a misconfigured `midpoint-admin` secret or an
+unexpected service address.
+
+## Gather diagnostics first
+
+Run the helper script to capture the current Argo CD state, job logs, midPoint pod status and the
+CloudNativePG resources:
+
+```bash
+./scripts/collect_midpoint_diagnostics.sh
+```
+
+Focus on the following sections of the output:
+
+* **Seeder job logs** – repeated HTTP status codes show whether the job can reach the REST API and whether the
+  credentials are valid. If you see `HTTP 401` or `HTTP 403`, the administrator password in the
+  `midpoint-admin` secret is wrong. `HTTP 404` indicates the job cannot reach the `/ws/rest/version` endpoint
+  at the expected service name.
+* **midPoint pod init containers** – look for failures in the `midpoint-db-wait`, `repo-init` or
+  `midpoint-db-init` init containers. They surface database connectivity issues and schema bootstrap errors.
+* **CloudNativePG cluster and database resources** – confirm the `iam-db` cluster is `Ready` and the
+  `database/midpoint` custom resource reports `DatabaseReady` in its conditions.
+
+Collecting this information ensures we understand whether the failure is caused by midPoint startup issues,
+database availability or incorrect credentials before applying a fix.
+
+## Proposed fix – Attempt 1
+
+**Goal:** bring midPoint to a healthy state so the seeder job can complete successfully.
+
+1. **Fix credential mismatches first.** If the job fails immediately with `HTTP 401` or `HTTP 403`, update the
+   `midpoint-admin` secret in [`gitops/apps/iam/secrets/kustomization.yaml`](../../gitops/apps/iam/secrets/kustomization.yaml)
+   with the correct administrator password and commit the change. Argo CD will recreate the secret and the next
+   seeder job run will succeed.
+2. **Investigate midPoint pod failures.** When the init containers fail, inspect their logs for errors such as
+   `timed out waiting for PostgreSQL` or SQL exceptions. Resolve database availability issues by ensuring the
+   CloudNativePG cluster (`kubectl get cluster iam-db -n iam`) reports `Ready` and that the managed roles exist.
+   If the repository bootstrap fails due to data drift, consider resetting the cluster or restoring from a
+   known-good backup.
+3. **Verify service reachability.** If the job reports `HTTP 404`, confirm the `MIDPOINT_URL` value points to
+   the in-cluster service (`http://midpoint:8080/midpoint`). Check for stray overrides in the job environment or
+   service name changes in [`gitops/apps/iam/midpoint/deployment.yaml`](../../gitops/apps/iam/midpoint/deployment.yaml).
+
+After applying the fix, delete the existing seeder job (or allow Argo CD to recreate it during the next sync)
+so it runs with the corrected configuration:
+
+```bash
+kubectl delete job midpoint-seeder -n iam
+argocd app sync iam
+```
+
+The IAM application should leave the `waiting for resources` state once the midPoint pods reach `Ready` and the
+seeder job completes successfully.

--- a/gitops/apps/iam/midpoint/seeder-job.yaml
+++ b/gitops/apps/iam/midpoint/seeder-job.yaml
@@ -67,7 +67,7 @@ spec:
               ready=0
               while [ "${attempt}" -le "${wait_attempts}" ]; do
                 http_code="$(curl -sS -o /dev/null -u "$auth" -w '%{http_code}' \
-                  "$MP_URL/ws/rest/version" || true)"
+                  "$MP_URL/ws/rest/version" || echo '000')"
 
                 case "${http_code}" in
                 200)
@@ -75,14 +75,28 @@ spec:
                   ready=1
                   break
                   ;;
+                401|403)
+                  echo "ERROR: received HTTP ${http_code} from midPoint REST API; administrator credentials are invalid" >&2
+                  echo "       Check the midpoint-admin secret before re-running the job" >&2
+                  exit 1
+                  ;;
+                404)
+                  echo "ERROR: midPoint REST endpoint ${MP_URL}/ws/rest/version returned HTTP ${http_code}" >&2
+                  echo "       Verify the MIDPOINT_URL value and that the service is exposed" >&2
+                  exit 1
+                  ;;
+                000)
+                  echo "midPoint endpoint not reachable [${attempt}/${wait_attempts}]"
+                  ;;
                 *)
                   echo "midPoint not ready yet (HTTP ${http_code}) [${attempt}/${wait_attempts}]"
-                  attempt=$((attempt + 1))
-                  if [ "${attempt}" -le "${wait_attempts}" ]; then
-                    sleep "${wait_sleep}"
-                  fi
                   ;;
                 esac
+
+                attempt=$((attempt + 1))
+                if [ "${attempt}" -le "${wait_attempts}" ]; then
+                  sleep "${wait_sleep}"
+                fi
               done
 
               if [ "${ready}" -ne 1 ]; then

--- a/scripts/collect_midpoint_diagnostics.sh
+++ b/scripts/collect_midpoint_diagnostics.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+error() {
+  echo "[error] $*" >&2
+}
+
+warn() {
+  echo "[warn] $*" >&2
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    error "Required command '$cmd' not found in PATH"
+    exit 1
+  fi
+}
+
+section() {
+  local title="$1"
+  printf '\n===== %s =====\n' "$title"
+}
+
+run_cmd() {
+  local description="$1"
+  shift
+
+  section "$description"
+  if "$@"; then
+    return 0
+  fi
+
+  local status=$?
+  error "Command failed with status $status: $*"
+  return 0
+}
+
+require_cmd kubectl
+require_cmd jq
+
+MIDPOINT_NAMESPACE=${MIDPOINT_NAMESPACE:-iam}
+MIDPOINT_APP_NAME=${MIDPOINT_APP_NAME:-iam}
+MIDPOINT_POD_SELECTOR=${MIDPOINT_POD_SELECTOR:-app=midpoint}
+MIDPOINT_SEEDER_JOB=${MIDPOINT_SEEDER_JOB:-midpoint-seeder}
+CNPG_CLUSTER_NAME=${CNPG_CLUSTER_NAME:-iam-db}
+
+if command -v argocd >/dev/null 2>&1; then
+  run_cmd "Argo CD application summary (${MIDPOINT_APP_NAME})" \
+    argocd app get "${MIDPOINT_APP_NAME}"
+else
+  warn "'argocd' CLI not found; skipping Argo CD application summary"
+fi
+
+run_cmd "Argo CD operation state (${MIDPOINT_APP_NAME})" bash -c \
+  "kubectl get application ${MIDPOINT_APP_NAME} -n argocd -o json \
+    | jq '.status.operationState | {phase, message, syncResult: .syncResult.resources[]? | select(.status == \"OutOfSync\")}'"
+
+run_cmd "midPoint deployment" \
+  kubectl get deployment/midpoint -n "${MIDPOINT_NAMESPACE}" -o yaml
+
+run_cmd "midPoint seeder job" \
+  kubectl get job "${MIDPOINT_SEEDER_JOB}" -n "${MIDPOINT_NAMESPACE}" -o yaml
+
+run_cmd "midPoint seeder job pods" \
+  kubectl get pods -n "${MIDPOINT_NAMESPACE}" --selector="job-name=${MIDPOINT_SEEDER_JOB}" -o wide
+
+if kubectl get job "${MIDPOINT_SEEDER_JOB}" -n "${MIDPOINT_NAMESPACE}" >/dev/null 2>&1; then
+  run_cmd "midPoint seeder job logs" \
+    kubectl logs job/"${MIDPOINT_SEEDER_JOB}" -n "${MIDPOINT_NAMESPACE}" --tail=200
+fi
+
+run_cmd "midPoint pods" \
+  kubectl get pods -n "${MIDPOINT_NAMESPACE}" -l "${MIDPOINT_POD_SELECTOR}" -o wide
+
+mapfile -t midpoint_pods < <(
+  kubectl get pods -n "${MIDPOINT_NAMESPACE}" -l "${MIDPOINT_POD_SELECTOR}" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true
+)
+
+print_container_logs() {
+  local pod="$1"
+  local container="$2"
+  local type="$3"
+
+  run_cmd "${type} logs for pod ${pod} container ${container}" \
+    kubectl logs "${pod}" -n "${MIDPOINT_NAMESPACE}" -c "${container}" --tail=200
+}
+
+if ((${#midpoint_pods[@]} == 0)); then
+  warn "No midPoint pods found with selector '${MIDPOINT_POD_SELECTOR}' in namespace '${MIDPOINT_NAMESPACE}'"
+
+  run_cmd "Pods in namespace ${MIDPOINT_NAMESPACE} (showing labels)" \
+    kubectl get pods -n "${MIDPOINT_NAMESPACE}" --show-labels
+else
+  for pod in "${midpoint_pods[@]}"; do
+    run_cmd "Describe midPoint pod ${pod}" \
+      kubectl describe pod "${pod}" -n "${MIDPOINT_NAMESPACE}"
+
+    mapfile -t init_containers < <(
+      kubectl get pod "${pod}" -n "${MIDPOINT_NAMESPACE}" \
+        -o jsonpath='{range .spec.initContainers[*]}{.name}{"\n"}{end}' 2>/dev/null || true
+    )
+
+    for container in "${init_containers[@]}"; do
+      print_container_logs "${pod}" "${container}" "Init"
+    done
+
+    mapfile -t app_containers < <(
+      kubectl get pod "${pod}" -n "${MIDPOINT_NAMESPACE}" \
+        -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' 2>/dev/null || true
+    )
+
+    for container in "${app_containers[@]}"; do
+      print_container_logs "${pod}" "${container}" "Container"
+    done
+  done
+fi
+
+run_cmd "CloudNativePG cluster status" \
+  kubectl get cluster "${CNPG_CLUSTER_NAME}" -n "${MIDPOINT_NAMESPACE}" -o yaml
+
+run_cmd "CloudNativePG databases" \
+  kubectl get databases.postgresql.cnpg.io -n "${MIDPOINT_NAMESPACE}" -o wide
+
+run_cmd "midPoint database resource" \
+  kubectl get database/midpoint -n "${MIDPOINT_NAMESPACE}" -o yaml
+
+run_cmd "CNPG pods" \
+  kubectl get pods -n "${MIDPOINT_NAMESPACE}" -l "cnpg.io/cluster=${CNPG_CLUSTER_NAME}" -o wide
+
+warn "Review the seeder job logs for repeated HTTP 401/403 responses; these now fail fast when credentials are wrong."


### PR DESCRIPTION
## Summary
- make the midPoint seeder job fail fast on authentication and routing errors so Argo CD surfaces actionable feedback
- add a troubleshooting runbook and diagnostics script for IAM syncs that report "waiting for resources"
- document the new runbook in the repository README for easier discovery

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68dc60d1b05c832b83f4d46cfbb0a1fd