### PR TITLE
Align Argo sync waves for IAM stack

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rws-keycloak
   namespace: iam
   annotations:
-    argocd.argoproj.io/sync-wave: "30"
+    argocd.argoproj.io/sync-wave: "20"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   image: quay.io/keycloak/keycloak:26.3.5

--- a/gitops/apps/iam/midpoint/deployment.yaml
+++ b/gitops/apps/iam/midpoint/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: midpoint
   namespace: iam
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
 spec:
   replicas: 1
   # MidPoint's first boot performs a sizeable schema bootstrap and application

--- a/gitops/clusters/aks/apps/platform-charts.applicationset.yaml
+++ b/gitops/clusters/aks/apps/platform-charts.applicationset.yaml
@@ -45,6 +45,8 @@ spec:
   template:
     metadata:
       name: '{{.name}}'
+      annotations:
+        argocd.argoproj.io/sync-wave: "5"
     spec:
       project: platform
       destination:


### PR DESCRIPTION
## Summary
- set Keycloak to wave 20 and midPoint to wave 30 so the database, Keycloak, and midPoint reconcile in order
- annotate the platform-addons ApplicationSet with wave 5 so operators and CRDs sync before the IAM application

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc9542b08832bbed26f6bfb9a46b4