### PR TITLE
Fix Keycloak proxy headers configuration

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -23,6 +23,8 @@ spec:
       value: local
     - name: proxy
       value: edge
+    - name: proxy-headers
+      value: xforwarded
   features:
     enabled:
       - token-exchange
@@ -30,8 +32,6 @@ spec:
     hostname: kc.132.164.56.132.nip.io
     strict: false
     strictBackchannel: false
-  proxy:
-    headers: xforwarded
   http:
     httpEnabled: true
 


### PR DESCRIPTION
## Summary
- add the proxy-headers flag to the Keycloak additional options so the operator passes trusted header configuration to the pod
- drop the deprecated spec.proxy.headers stanza that is rejected by the 26.x CRD

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dcd482f674832bbb96b87cda19f248