### PR TITLE
Fix CNPG managed role secret schema

### DIFF
--- a/gitops/apps/iam/cnpg/cluster.yaml
+++ b/gitops/apps/iam/cnpg/cluster.yaml
@@ -56,7 +56,6 @@ spec:
         connectionLimit: -1
         passwordSecret:
           name: keycloak-db-app
-          key: password
       - name: midpoint
         ensure: present
         login: true
@@ -64,4 +63,3 @@ spec:
         connectionLimit: -1
         passwordSecret:
           name: midpoint-db-app
-          key: password

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -178,13 +178,11 @@ def test_cnpg_cluster_handles_missing_crds_and_roles():
     assert keycloak_role is not None, "keycloak role should be managed"
     keycloak_secret = keycloak_role.get("passwordSecret", {})
     assert keycloak_secret.get("name") == "keycloak-db-app"
-    assert keycloak_secret.get("key") == "password"
 
     midpoint_role = find_role("midpoint")
     assert midpoint_role is not None, "midpoint role should remain managed"
     midpoint_secret = midpoint_role.get("passwordSecret", {})
     assert midpoint_secret.get("name") == "midpoint-db-app"
-    assert midpoint_secret.get("key") == "password"
 
 
 def test_cnpg_databases_skip_dry_run():


### PR DESCRIPTION
## Summary
- remove the unsupported `key` field from CNPG managed role passwordSecret blocks so the CRD validates
- adjust the GitOps structure tests to reflect the simplified secret selector

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcf0bafd24832b8e75781401b55f1d