### PR TITLE
Fix Keycloak ingress class field

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -44,7 +44,7 @@ spec:
 
   ingress:
     enabled: true
-    ingressClassName: nginx
+    className: nginx
     path: /
     pathType: Prefix
     annotations:

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -26,7 +26,7 @@ replacements:
           kind: Keycloak
           name: rws-keycloak
         fieldPaths:
-          - spec.ingress.ingressClassName
+          - spec.ingress.className
       - select:
           kind: Ingress
           name: keycloak

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -105,7 +105,7 @@ def test_iam_ingress_replacements_cover_all_targets():
                         return True
         return False
 
-    assert has_replacement("data.ingressClass", "Keycloak", "rws-keycloak", "spec.ingress.ingressClassName")
+    assert has_replacement("data.ingressClass", "Keycloak", "rws-keycloak", "spec.ingress.className")
     assert has_replacement("data.ingressClass", "Ingress", "keycloak", "spec.ingressClassName")
     assert has_replacement("data.ingressClass", "Ingress", "midpoint", "spec.ingressClassName")
     assert has_replacement("data.keycloakHost", "Keycloak", "rws-keycloak", "spec.hostname.hostname")


### PR DESCRIPTION
## Summary
- replace the unsupported `spec.ingress.ingressClassName` field in the Keycloak CR with the correct `spec.ingress.className`
- update IAM Kustomize replacements and accompanying tests to use the new field path

## Testing
- pytest tests/test_gitops_structure.py

------
https://chatgpt.com/codex/tasks/task_e_68dcff105cf8832bb07f3bb22e9c74cf