### PR TITLE
Reorder ingress host rotation during bootstrap

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -298,6 +298,15 @@ jobs:
             --timeout "${INGRESS_LB_TIMEOUT:-900}" \
             --interval "${INGRESS_LB_INTERVAL:-15}"
 
+      - name: Configure demo ingress hosts
+        id: configure
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/configure_demo_hosts.py \
+            --params-file gitops/apps/iam/params.env \
+            --skip-reachability-check
+
       - name: Wait for IAM application
         shell: bash
         run: |
@@ -384,15 +393,6 @@ jobs:
             echo "IAM_APP_FAILURE_REASON=${failure_reason}"
             echo "IAM_APP_LAST_OPERATION_MESSAGE=${operation_message}"
           } >>"${GITHUB_ENV}"
-
-      - name: Configure demo ingress hosts
-        id: configure
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 scripts/configure_demo_hosts.py \
-            --params-file gitops/apps/iam/params.env \
-            --skip-reachability-check
 
       - name: Wait for ingress endpoints to become reachable
         shell: bash


### PR DESCRIPTION
## Summary
- move the configure_demo_hosts invocation immediately after ensuring the ingress load balancer is ready
- keep the IAM health wait after host rotation so stale nip.io references fail fast without delaying diagnostics

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd02e806a0832ba0ed927029698ed2