### PR TITLE
Include Keycloak ingress manifest in host rotation defaults

### DIFF
--- a/scripts/configure_demo_hosts.py
+++ b/scripts/configure_demo_hosts.py
@@ -19,6 +19,7 @@ DEFAULT_EXTRA_PARAMS_FILES = [Path("gitops/clusters/aks/bootstrap/params.env")]
 DEFAULT_SERVICE = "ingress-nginx/ingress-nginx-controller"
 DEFAULT_MANIFEST_FILES = [
     Path("gitops/apps/iam/keycloak/keycloak.yaml"),
+    Path("gitops/apps/iam/keycloak/ingress.yaml"),
     Path("gitops/apps/iam/midpoint/ingress.yaml"),
     Path("gitops/clusters/aks/bootstrap/argocd-ingress.yaml"),
 ]


### PR DESCRIPTION
## Summary
- include the Keycloak ingress manifest in the default files updated by configure_demo_hosts so nip.io hosts stay in sync

## Testing
- python -m compileall scripts/configure_demo_hosts.py

------
https://chatgpt.com/codex/tasks/task_e_68dd057e823c832bb8e037feb0eabbef