### PR TITLE
fix: align keycloak ingress spec with crd

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -45,8 +45,6 @@ spec:
   ingress:
     enabled: true
     className: nginx
-    path: /
-    pathType: Prefix
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"


### PR DESCRIPTION
## Summary
- remove unsupported path fields from the Keycloak ingress specification to satisfy the operator CRD

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd06cfb2bc832b9a4b771cd51071b3