### PR TITLE
Disable Keycloak operator-managed ingress configuration

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -43,9 +43,4 @@ spec:
     passwordSecret: { name: keycloak-db-app, key: password }
 
   ingress:
-    enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    enabled: false

--- a/gitops/apps/iam/kustomization.yaml
+++ b/gitops/apps/iam/kustomization.yaml
@@ -23,11 +23,6 @@ replacements:
       fieldPath: data.ingressClass
     targets:
       - select:
-          kind: Keycloak
-          name: rws-keycloak
-        fieldPaths:
-          - spec.ingress.className
-      - select:
           kind: Ingress
           name: keycloak
         fieldPaths:

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -105,7 +105,6 @@ def test_iam_ingress_replacements_cover_all_targets():
                         return True
         return False
 
-    assert has_replacement("data.ingressClass", "Keycloak", "rws-keycloak", "spec.ingress.className")
     assert has_replacement("data.ingressClass", "Ingress", "keycloak", "spec.ingressClassName")
     assert has_replacement("data.ingressClass", "Ingress", "midpoint", "spec.ingressClassName")
     assert has_replacement("data.keycloakHost", "Keycloak", "rws-keycloak", "spec.hostname.hostname")


### PR DESCRIPTION
## Summary
- disable the Keycloak custom resource ingress block so the operator no longer receives unsupported fields
- remove the kustomize replacement that targeted the Keycloak ingress class and adjust the GitOps structure test

## Testing
- pytest tests/test_gitops_structure.py

------
https://chatgpt.com/codex/tasks/task_e_68dd081e5940832b9dffe8424455c689