### PR TITLE
Update demo ingress hosts to new external IP

### DIFF
--- a/gitops/apps/iam/keycloak/ingress.yaml
+++ b/gitops/apps/iam/keycloak/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: kc.132.164.56.132.nip.io
+    - host: kc.4.245.81.5.nip.io
       http:
         paths:
           - path: /

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -29,7 +29,7 @@ spec:
     enabled:
       - token-exchange
   hostname:
-    hostname: kc.132.164.56.132.nip.io
+    hostname: kc.4.245.81.5.nip.io
     strict: false
     strictBackchannel: false
   http:

--- a/gitops/apps/iam/midpoint/ingress.yaml
+++ b/gitops/apps/iam/midpoint/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: mp.132.164.56.132.nip.io
+    - host: mp.4.245.81.5.nip.io
       http:
         paths:
           - path: /

--- a/gitops/apps/iam/params.env
+++ b/gitops/apps/iam/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.132.164.56.132.nip.io
-midpointHost=mp.132.164.56.132.nip.io
-argocdHost=argocd.132.164.56.132.nip.io
+keycloakHost=kc.4.245.81.5.nip.io
+midpointHost=mp.4.245.81.5.nip.io
+argocdHost=argocd.4.245.81.5.nip.io

--- a/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
+++ b/gitops/clusters/aks/bootstrap/argocd-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: argocd.132.164.56.132.nip.io
+    - host: argocd.4.245.81.5.nip.io
       http:
         paths:
           - path: /

--- a/gitops/clusters/aks/bootstrap/params.env
+++ b/gitops/clusters/aks/bootstrap/params.env
@@ -2,6 +2,6 @@
 # Hosts rotate via scripts/configure_demo_hosts.py; update ingressClass here if
 # your cluster uses a different controller.
 ingressClass=nginx
-keycloakHost=kc.132.164.56.132.nip.io
-midpointHost=mp.132.164.56.132.nip.io
-argocdHost=argocd.132.164.56.132.nip.io
+keycloakHost=kc.4.245.81.5.nip.io
+midpointHost=mp.4.245.81.5.nip.io
+argocdHost=argocd.4.245.81.5.nip.io


### PR DESCRIPTION
## Summary
- update the bootstrap and IAM app parameter files to use 4.245.81.5-based nip.io hostnames
- align Keycloak, MidPoint, and Argo CD ingress rules with the new external IP

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0e923044832ba07ea544670ac4fc