### PR TITLE
Declare CNPG database defaults and drop ignore override

### DIFF
--- a/gitops/apps/iam/cnpg/database-keycloak.yaml
+++ b/gitops/apps/iam/cnpg/database-keycloak.yaml
@@ -7,6 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "20"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
+  ensure: present
+  databaseReclaimPolicy: retain
   cluster:
     name: iam-db
   name: keycloak

--- a/gitops/apps/iam/cnpg/database-midpoint.yaml
+++ b/gitops/apps/iam/cnpg/database-midpoint.yaml
@@ -7,6 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "20"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
+  ensure: present
+  databaseReclaimPolicy: retain
   cluster:
     name: iam-db
   name: midpoint

--- a/gitops/clusters/aks/apps/iam.application.yaml
+++ b/gitops/clusters/aks/apps/iam.application.yaml
@@ -34,8 +34,3 @@ spec:
       namespace: iam
       jsonPointers:
         - /spec/realm
-    - group: postgresql.cnpg.io
-      kind: Database
-      jsonPointers:
-        - /spec/ensure
-        - /spec/databaseReclaimPolicy


### PR DESCRIPTION
## Summary
- explicitly set ensure and databaseReclaimPolicy on the Keycloak and MidPoint CNPG Database manifests to prevent drift
- remove the Argo CD ignoreDifferences override now that the manifests declare the desired defaults

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd1a1fb618832b908c8ea21432bdc1