### PR TITLE
Remove redundant MidPoint repo-init init container

### DIFF
--- a/gitops/apps/iam/midpoint/deployment.yaml
+++ b/gitops/apps/iam/midpoint/deployment.yaml
@@ -133,40 +133,6 @@ spec:
             - name: midpoint-db-credentials
               mountPath: /var/run/secrets/midpoint-db
               readOnly: true
-        - name: repo-init
-          image: evolveum/midpoint:4.9-alpine
-          workingDir: /opt/midpoint
-          command:
-            - sh
-            - -lc
-            - >
-              bin/midpoint.sh init-native &&
-              bin/ninja.sh run-sql --create --mode repository &&
-              bin/ninja.sh run-sql --create --mode audit
-          env:
-            - name: MP_SET_midpoint_repository_database
-              value: postgresql
-            - name: MP_SET_midpoint_repository_jdbcUrl
-              valueFrom:
-                secretKeyRef:
-                  name: midpoint-db
-                  key: jdbc-uri
-            - name: MP_SET_midpoint_repository_jdbcUsername
-              valueFrom:
-                secretKeyRef:
-                  name: midpoint-db
-                  key: username
-            - name: MP_SET_midpoint_repository_jdbcPassword
-              valueFrom:
-                secretKeyRef:
-                  name: midpoint-db
-                  key: password
-            - name: MP_SET_midpoint_repository_missingSchemaAction
-              value: "create"
-            - name: MP_UNSET_midpoint_repository_hibernateHbm2ddl
-              value: "1"
-            - name: MP_NO_ENV_COMPAT
-              value: "1"
         - name: midpoint-db-init
           image: evolveum/midpoint:4.9
           workingDir: /opt/midpoint


### PR DESCRIPTION
## Summary
- remove the MidPoint repo-init initContainer that re-ran schema creation logic
- rely on the existing midpoint-db-init script to handle bootstrap and upgrades idempotently

## Testing
- kustomize build gitops/apps/iam *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1c478b30832bbab72aaa8df80141