### PR TITLE
Configure Keycloak proxy headers via CR spec

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -23,8 +23,6 @@ spec:
       value: local
     - name: proxy
       value: edge
-    - name: proxy-headers
-      value: xforwarded
   features:
     enabled:
       - token-exchange
@@ -34,6 +32,8 @@ spec:
     strictBackchannel: false
   http:
     httpEnabled: true
+  proxy:
+    headers: xforwarded
 
   db:
     vendor: postgres


### PR DESCRIPTION
## Summary
- move the Keycloak proxy headers setting out of additional options and into the dedicated CR spec field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1c478b30832bbab72aaa8df80141