### PR TITLE
Fix Keycloak proxy header configuration

### DIFF
--- a/docs/troubleshooting/keycloak-proxy-warning.md
+++ b/docs/troubleshooting/keycloak-proxy-warning.md
@@ -17,14 +17,13 @@ When the Keycloak operator renders the Quarkus distribution without an explicit 
 
 Update the GitOps source of truth so Keycloak honours the headers injected by the ingress controller:
 
-1. Edit [`gitops/apps/iam/keycloak/keycloak.yaml`](../../gitops/apps/iam/keycloak/keycloak.yaml) and ensure the following entries exist under `spec.additionalOptions`:
+1. Edit [`gitops/apps/iam/keycloak/keycloak.yaml`](../../gitops/apps/iam/keycloak/keycloak.yaml) and ensure the following `spec.proxy` configuration is present:
    ```yaml
-   - name: proxy
-     value: edge
-   - name: proxy-headers
-     value: xforwarded
+   proxy:
+     mode: edge
+     headers: xforwarded
    ```
-   The `edge` proxy mode tells Keycloak to expect TLS termination at the ingress boundary, while `xforwarded` enables parsing of the forwarded headers.
+   The `edge` proxy mode tells Keycloak to expect TLS termination at the ingress boundary, while `xforwarded` enables parsing of the forwarded headers. Newer Keycloak operator releases surface these options as first-class fields; leaving them in `additionalOptions` triggers validation warnings and will be removed in a future API version.
 2. Commit and push the change. Argo CD will roll the Keycloak StatefulSet to pick up the new configuration.
 3. After the rollout completes, confirm the warning disappeared:
    ```bash

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -21,8 +21,6 @@ spec:
       value: "0.0.0.0"
     - name: cache
       value: local
-    - name: proxy
-      value: edge
   features:
     enabled:
       - token-exchange
@@ -34,6 +32,7 @@ spec:
     httpEnabled: true
   proxy:
     headers: xforwarded
+    mode: edge
 
   db:
     vendor: postgres


### PR DESCRIPTION
## Summary
- switch the Keycloak CR to the first-class proxy.mode/headers fields instead of additionalOptions
- document the new configuration path in the proxy warning troubleshooting guide

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd217dd764832b9458764d6ae0edf5