### PR TITLE
Configure Keycloak proxy via first-class fields

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -21,8 +21,6 @@ spec:
       value: "0.0.0.0"
     - name: cache
       value: local
-    - name: proxy
-      value: edge
   features:
     enabled:
       - token-exchange
@@ -33,7 +31,9 @@ spec:
   http:
     httpEnabled: true
   proxy:
-    headers: xforwarded
+    mode: edge
+    headers:
+      - xforwarded
 
   db:
     vendor: postgres


### PR DESCRIPTION
## Summary
- switch the Keycloak manifest to use the dedicated proxy.mode and proxy.headers fields instead of legacy additionalOptions entries
- document the new configuration flow in the proxy warning troubleshooting guide and advise removing deprecated flags

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd217dd764832b9458764d6ae0edf5