### PR TITLE
Fix Keycloak proxy headers type

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -32,8 +32,7 @@ spec:
     httpEnabled: true
   proxy:
     mode: edge
-    headers:
-      - xforwarded
+    headers: xforwarded
 
   db:
     vendor: postgres

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -202,6 +202,10 @@ def test_keycloak_resources_skip_dry_run_and_wave_ordering():
         == "SkipDryRunOnMissingResource=true"
     ), "Keycloak CR should skip dry-run while CRDs install"
 
+    proxy = keycloak["spec"].get("proxy", {})
+    headers = proxy.get("headers")
+    assert isinstance(headers, str) and headers == "xforwarded", "Keycloak proxy headers must be a string"
+
     realm = load_yaml(REPO_ROOT / "gitops/apps/iam/keycloak/rws-realm.yaml")
     realm_annotations = realm["metadata"].get("annotations", {})
     assert (


### PR DESCRIPTION
## Summary
- update the Keycloak custom resource to set the proxy headers field to the string value expected by the CRD
- extend the GitOps structure test to assert that the Keycloak proxy headers configuration remains a string

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd2e7e0060832b8262f797a718ba83