### PR TITLE
Persist demo host env vars across workflow steps

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -336,9 +336,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          tmp_env=$(mktemp)
           python3 scripts/configure_demo_hosts.py \
             --params-file gitops/apps/iam/params.env \
-            --skip-reachability-check
+            --skip-reachability-check \
+            --env-file "${tmp_env}"
+
+          echo "🔧 computed hosts:"
+          cat "${tmp_env}"
+
+          grep -E '^(EXTERNAL_IP|KC_HOST|MP_HOST|ARGOCD_HOST)=' "${tmp_env}" >> "${GITHUB_ENV}"
 
       - name: Force hard recreate of IAM deployment
         shell: bash


### PR DESCRIPTION
## Summary
- add an --env-file option to configure_demo_hosts.py so the script can emit KEY=VALUE assignments alongside $GITHUB_ENV updates
- update the bootstrap workflow to capture the generated env file, log the values, and append the host variables to $GITHUB_ENV for later steps

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd2eacadfc832b93816a9a1144c95b