### PR TITLE
Persist demo host env vars across workflow steps

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -336,9 +336,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 scripts/configure_demo_hosts.py \
+          tmp_env=$(mktemp)
+          CONFIGURE_DEMO_HOSTS_SKIP_DIRECT_ENV=1 python3 scripts/configure_demo_hosts.py \
             --params-file gitops/apps/iam/params.env \
-            --skip-reachability-check
+            --skip-reachability-check \
+            > "${tmp_env}"
+
+          echo "🔧 computed hosts:"
+          cat "${tmp_env}"
+
+          grep -E '^(EXTERNAL_IP|KC_HOST|MP_HOST|ARGOCD_HOST)=' "${tmp_env}" >> "${GITHUB_ENV}"
 
       - name: Force hard recreate of IAM deployment
         shell: bash

--- a/scripts/configure_demo_hosts.py
+++ b/scripts/configure_demo_hosts.py
@@ -227,6 +227,15 @@ def write_params(params_file: Path, ingress_class: str, hosts: Hosts) -> None:
     )
 
 
+def iter_environment_lines(ip_address: str, hosts: Hosts) -> Iterable[str]:
+    """Yield environment variable declarations for the discovered hosts."""
+
+    yield f"EXTERNAL_IP={ip_address}"
+    yield f"KC_HOST={hosts.keycloak}"
+    yield f"MP_HOST={hosts.midpoint}"
+    yield f"ARGOCD_HOST={hosts.argocd}"
+
+
 def update_manifest_hosts(manifest_files: Iterable[Path], hosts: Hosts) -> None:
     """Update nip.io host references within manifest files."""
 
@@ -389,13 +398,18 @@ def main() -> int:
     validation_paths = getattr(args, "validation_path", DEFAULT_VALIDATION_PATHS)
     ensure_hosts_rotated(validation_paths, ip_value)
 
+    env_lines = list(iter_environment_lines(ip_value, hosts))
+    for line in env_lines:
+        print(line)
+
+    print()
+
     github_env = os.environ.get("GITHUB_ENV")
-    if github_env:
+    skip_env_write = os.environ.get("CONFIGURE_DEMO_HOSTS_SKIP_DIRECT_ENV", "").lower()
+    if github_env and skip_env_write not in {"1", "true", "yes", "on"}:
         with open(github_env, "a", encoding="utf-8") as env_file:
-            env_file.write(f"EXTERNAL_IP={ip_value}\n")
-            env_file.write(f"KC_HOST={hosts.keycloak}\n")
-            env_file.write(f"MP_HOST={hosts.midpoint}\n")
-            env_file.write(f"ARGOCD_HOST={hosts.argocd}\n")
+            for line in env_lines:
+                env_file.write(f"{line}\n")
 
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:

--- a/tests/test_configure_demo_hosts.py
+++ b/tests/test_configure_demo_hosts.py
@@ -25,7 +25,7 @@ def test_write_and_read_params(tmp_path: Path):
     assert cd.read_ingress_class(params) == "custom"
 
 
-def test_main_updates_env_files(monkeypatch, tmp_path: Path):
+def test_main_updates_env_files(monkeypatch, tmp_path: Path, capsys):
     params = tmp_path / "params.env"
     params.write_text("ingressClass=test\n", encoding="utf-8")
 
@@ -64,6 +64,11 @@ def test_main_updates_env_files(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(cd, "parse_args", lambda: args)
 
     assert cd.main() == 0
+
+    captured = capsys.readouterr()
+    assert "KC_HOST=kc.203.0.113.10.nip.io" in captured.out
+    assert "MP_HOST=mp.203.0.113.10.nip.io" in captured.out
+    assert "ARGOCD_HOST=argocd.203.0.113.10.nip.io" in captured.out
 
     saved = params.read_text(encoding="utf-8")
     assert "keycloakHost=kc.203.0.113.10.nip.io" in saved


### PR DESCRIPTION
## Summary
- emit EXTERNAL_IP and host variables from configure_demo_hosts.py while allowing workflows to disable direct $GITHUB_ENV writes
- capture the configure_demo_hosts.py output in the bootstrap workflow and append the host values into $GITHUB_ENV for later steps
- expand the unit test to assert the emitted environment lines

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd2eacadfc832b93816a9a1144c95b