### PR TITLE
Improve guidance when Keycloak CR is missing

### DIFF
--- a/docs/troubleshooting/keycloak-cr-missing.md
+++ b/docs/troubleshooting/keycloak-cr-missing.md
@@ -38,9 +38,16 @@ kubectl get pods -n iam --show-labels
    kubectl get crd keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org
    ```
 2. **Resync the IAM application** – If the operator is ready, instruct Argo CD to reapply the Keycloak manifest. This recreates
-   the CR when it was deleted manually or after the first attempt failed because the CRDs were missing:
+   the CR when it was deleted manually or after the first attempt failed because the CRDs were missing. From a shell with the
+   Argo CD CLI:
    ```bash
    argocd app sync iam --resource k8s.keycloak.org/Keycloak:iam/rws-keycloak
+   argocd app wait iam --timeout 180 --health
+   ```
+   When you do not have CLI access, trigger **Sync** in the Argo CD UI for the `iam` application (select the Keycloak resource)
+   or ask a teammate with access to run the command. As a last resort you can reapply the GitOps manifest directly:
+   ```bash
+   kubectl apply -f gitops/apps/iam/keycloak/keycloak.yaml
    ```
 3. **Investigate persistent failures** – When the sync fails again, inspect the Argo CD operation state to find the recorded error
    (for example `no matches for kind "Keycloak"`). Capture the Keycloak operator logs for the same time window—they confirm

--- a/scripts/collect_keycloak_diagnostics.sh
+++ b/scripts/collect_keycloak_diagnostics.sh
@@ -71,6 +71,11 @@ section "Keycloak custom resource status"
 if ! kubectl get keycloak "${KEYCLOAK_NAME}" -n "${KEYCLOAK_NAMESPACE}" -o yaml; then
   keycloak_cr_missing=1
   warn "Keycloak custom resource ${KEYCLOAK_NAMESPACE}/${KEYCLOAK_NAME} not found; see docs/troubleshooting/keycloak-cr-missing.md"
+  if command -v argocd >/dev/null 2>&1; then
+    warn "Recreate it with: argocd app sync iam --resource k8s.keycloak.org/Keycloak:${KEYCLOAK_NAMESPACE}/${KEYCLOAK_NAME}"
+  else
+    warn "Trigger an Argo CD sync from the UI or reapply gitops/apps/iam/keycloak/keycloak.yaml to recreate the resource"
+  fi
 fi
 
 section "Describe Keycloak custom resource"


### PR DESCRIPTION
## Summary
- have the diagnostics script suggest the appropriate Argo CD sync command when the Keycloak custom resource is missing
- expand the runbook with CLI, UI, and kubectl options for recreating the Keycloak custom resource and waiting for health

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd33a76964832b956e01ca7906c16d