### PR TITLE
Capture Keycloak realm import state in diagnostics

### DIFF
--- a/docs/troubleshooting/keycloak-cr-missing.md
+++ b/docs/troubleshooting/keycloak-cr-missing.md
@@ -15,8 +15,9 @@ showing the resource as missing until the manifest is applied successfully.
 
 ## Gather context first
 
-Run `./scripts/collect_keycloak_diagnostics.sh`. When the CR is missing the script highlights the failed `kubectl get` calls
-and lists the current pods in the namespace. Keep this output for the incident record.
+Run `./scripts/collect_keycloak_diagnostics.sh`. When the CR is missing the script highlights the failed `kubectl get` calls,
+lists the current pods in the namespace, and captures the state of any `KeycloakRealmImport` resources or jobs that may be
+waiting for the Keycloak server to exist. Keep this output for the incident record.
 
 If you prefer to run the commands manually:
 
@@ -26,6 +27,8 @@ kubectl get application iam -n argocd -o json \
 
 kubectl get keycloak rws-keycloak -n iam -o yaml
 kubectl describe keycloak rws-keycloak -n iam
+kubectl get keycloakrealmimports -n iam -o wide
+kubectl get jobs -n iam -l app=keycloak-realm-import --show-labels
 kubectl get pods -n iam --show-labels
 ```
 

--- a/scripts/collect_keycloak_diagnostics.sh
+++ b/scripts/collect_keycloak_diagnostics.sh
@@ -82,6 +82,12 @@ fi
 run_cmd "Keycloak pods" \
   kubectl get pods -n "${KEYCLOAK_NAMESPACE}" -l "${KEYCLOAK_POD_SELECTOR}" -o wide
 
+run_cmd "Keycloak realm import custom resources" \
+  kubectl get keycloakrealmimports.k8s.keycloak.org -n "${KEYCLOAK_NAMESPACE}" -o wide
+
+run_cmd "Keycloak realm import jobs" \
+  kubectl get jobs -n "${KEYCLOAK_NAMESPACE}" -l app=keycloak-realm-import --show-labels
+
 mapfile -t keycloak_pods < <(
   kubectl get pods -n "${KEYCLOAK_NAMESPACE}" -l "${KEYCLOAK_POD_SELECTOR}" \
     -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true


### PR DESCRIPTION
## Summary
- extend the Keycloak diagnostics script to surface KeycloakRealmImport resources and realm import jobs
- document the additional diagnostics output in the missing Keycloak custom resource runbook

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd33a76964832b956e01ca7906c16d