### PR TITLE
Ensure IAM app refreshes after Keycloak CRDs

### DIFF
--- a/.github/workflows/02_bootstrap_argocd.yml
+++ b/.github/workflows/02_bootstrap_argocd.yml
@@ -279,6 +279,17 @@ jobs:
           echo 'Install the Keycloak operator (https://www.keycloak.org/operator/installation) and rerun the workflow.'
           exit 1
 
+      - name: Force Argo CD to refresh IAM application after CRDs install
+        shell: bash
+        run: |
+          set -euo pipefail
+          if kubectl -n argocd get application iam >/dev/null 2>&1; then
+            echo "Forcing a hard refresh on the iam application so Keycloak resources reconcile now that CRDs exist."
+            kubectl -n argocd patch application iam --type merge --patch '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
+          else
+            echo "IAM application not found yet; skipping forced refresh."
+          fi
+
       - name: Wait for platform addons
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- add a bootstrap step that forces Argo CD to refresh the IAM application after the Keycloak CRDs register
- guard the refresh so the workflow logs a helpful message if the application has not been created yet

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd33c4e23c832bbd164a0e79302968