### PR TITLE
Fix duplicate proxy mode key in Keycloak Kustomize manifest

### DIFF
--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -33,7 +33,6 @@ spec:
   proxy:
     mode: edge
     headers: xforwarded
-    mode: edge
 
   db:
     vendor: postgres


### PR DESCRIPTION
## Summary
- remove the duplicate `mode` entry from the Keycloak proxy configuration to restore valid YAML for kustomize

## Testing
- not run (kustomize is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd3d9e61b8832bbd0bc09fbfbebe41