### PR TITLE
Add ClusterIP service for Keycloak ingress backend

### DIFF
--- a/gitops/apps/iam/keycloak/kustomization.yaml
+++ b/gitops/apps/iam/keycloak/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - keycloak.yaml
+  - service.yaml
   - ingress.yaml
   - rws-realm.yaml

--- a/gitops/apps/iam/keycloak/service.yaml
+++ b/gitops/apps/iam/keycloak/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rws-keycloak-service
+  namespace: iam
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+spec:
+  type: ClusterIP
+  selector:
+    app: keycloak
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+    - name: http-direct
+      port: 8080
+      targetPort: 8080
+    - name: http-management
+      port: 9000
+      targetPort: 9000


### PR DESCRIPTION
## Summary
- add a dedicated ClusterIP service that selects the Keycloak pods and exposes HTTP and management ports
- include the new service in the Keycloak kustomization so the ingress backend resolves

## Testing
- kustomize build gitops/apps/iam/keycloak *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5cda9a20832b9b99f82eaec5b2dd