### PR TITLE
Work around Keycloak CRD proxy schema regression

### DIFF
--- a/docs/troubleshooting/keycloak-proxy-warning.md
+++ b/docs/troubleshooting/keycloak-proxy-warning.md
@@ -17,13 +17,15 @@ When the Keycloak operator renders the Quarkus distribution without an explicit 
 
 Update the GitOps source of truth so Keycloak honours the headers injected by the ingress controller:
 
-1. Edit [`gitops/apps/iam/keycloak/keycloak.yaml`](../../gitops/apps/iam/keycloak/keycloak.yaml) and ensure the following `spec.proxy` configuration is present:
+1. Edit [`gitops/apps/iam/keycloak/keycloak.yaml`](../../gitops/apps/iam/keycloak/keycloak.yaml) and ensure the following `additionalOptions` are present:
    ```yaml
-   proxy:
-     mode: edge
-     headers: xforwarded
+   additionalOptions:
+     - name: proxy
+       value: edge
+     - name: proxy-headers
+       value: xforwarded
    ```
-   The `edge` proxy mode tells Keycloak to expect TLS termination at the ingress boundary, while `xforwarded` enables parsing of the forwarded headers. Newer Keycloak operator releases surface these options as first-class fields; leaving them in `additionalOptions` triggers validation warnings and will be removed in a future API version.
+   The `edge` proxy mode tells Keycloak to expect TLS termination at the ingress boundary, while `xforwarded` enables parsing of the forwarded headers. The `v2alpha1` CRD shipped with operator 24.0 dropped the experimental `spec.proxy` structure, so the Quarkus CLI flags must be configured through `additionalOptions` again until a replacement lands.
 2. Commit and push the change. Argo CD will roll the Keycloak StatefulSet to pick up the new configuration.
 3. After the rollout completes, confirm the warning disappeared:
 

--- a/gitops/apps/iam/keycloak/keycloak.yaml
+++ b/gitops/apps/iam/keycloak/keycloak.yaml
@@ -21,6 +21,10 @@ spec:
       value: "0.0.0.0"
     - name: cache
       value: local
+    - name: proxy
+      value: edge
+    - name: proxy-headers
+      value: xforwarded
   features:
     enabled:
       - token-exchange
@@ -30,10 +34,6 @@ spec:
     strictBackchannel: false
   http:
     httpEnabled: true
-  proxy:
-    mode: edge
-    headers: xforwarded
-
   db:
     vendor: postgres
     url: "jdbc:postgresql://iam-db-rw.iam.svc.cluster.local:5432/keycloak?sslmode=require"

--- a/tests/test_gitops_structure.py
+++ b/tests/test_gitops_structure.py
@@ -202,9 +202,12 @@ def test_keycloak_resources_skip_dry_run_and_wave_ordering():
         == "SkipDryRunOnMissingResource=true"
     ), "Keycloak CR should skip dry-run while CRDs install"
 
-    proxy = keycloak["spec"].get("proxy", {})
-    headers = proxy.get("headers")
-    assert isinstance(headers, str) and headers == "xforwarded", "Keycloak proxy headers must be a string"
+    options = keycloak["spec"].get("additionalOptions", [])
+    options_by_name = {opt.get("name"): opt.get("value") for opt in options if isinstance(opt, dict)}
+    assert (
+        options_by_name.get("proxy-headers") == "xforwarded"
+    ), "Keycloak must enable xforwarded proxy headers"
+    assert options_by_name.get("proxy") == "edge", "Keycloak must run in edge proxy mode"
 
     realm = load_yaml(REPO_ROOT / "gitops/apps/iam/keycloak/rws-realm.yaml")
     realm_annotations = realm["metadata"].get("annotations", {})


### PR DESCRIPTION
## Summary
- configure proxy mode and headers through additionalOptions now that the v2alpha1 CRD rejects spec.proxy fields
- document the regression in the troubleshooting guide so operators know why the flags moved
- update the structural tests to enforce the new location for the proxy settings

## Testing
- pytest tests/test_gitops_structure.py


------
https://chatgpt.com/codex/tasks/task_e_68dd90132b50832bafb656a8c5288e79