### PR TITLE
Add network intent invariants documentation and golden path example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,15 @@ The tests cover the helper scripts and sanity-check the GitOps manifests (chart 
 
 - **Terraform destroy**: rerun the provisioning workflow with `TF_ACTION=destroy` or execute `terraform destroy` from `infra/azure/terraform` after running `terraform init` with the same backend settings as the pipeline.
 - **Pause the cluster**: `az aks stop --name <cluster> --resource-group <rg>` reduces costs without deleting anything.
+
+## Model invariants (network intent)
+
+The network intent model that feeds firewall and EVPN policies should be **closed by contract**: anything not explicitly allowed is forbidden. The following guardrails summarise the missing 10/10 items and link to detailed guidance in [`docs/model-invariants.md`](docs/model-invariants.md):
+
+- **L2VNI determinism:** every L2VNI carries `l2vni_base` and `vlan`; the invariant is `l2vni = l2vni_base + vlan` and OPA enforces the equality with path-aware error messages.
+- **Routing symmetry and leaks:** RTs remain symmetric and the only allowed route-leaks are host-route VIP exports via firewall VRFs; subnet exports are forbidden.
+- **Host-only VIPs:** VIP exports must be `/32` or `/128` (validated both in schema and OPA) with IPv6 normalised to a canonical form to avoid diff noise.
+- **Scoped flood domains:** L2VNIs are only activated on leaf-pairs within the mobility domain to keep the flood-set small; Ceph public VIPs are restricted to an allowlist of `/32` and `/128` endpoints.
+- **Strict-by-default policy:** `data.policy.strict = true` is the default; lenient mode is a conscious override in `data/`. Errors use `deny[msg]` with the full path and a hint to fix.
+
+For a minimal, convergent example with two tenants, one platform VRF and one storage VRF (including Ceph public VIPs), see [`examples/network-intent-golden-path.yaml`](examples/network-intent-golden-path.yaml). It demonstrates host-only VIP exports, dual-stack endpoints and mobility-scoped L2VNIs.

--- a/docs/model-invariants.md
+++ b/docs/model-invariants.md
@@ -1,0 +1,48 @@
+# Network intent model invariants
+
+Deze notitie documenteert welke harde invarianten, schema‑regels en OPA‑policies nog nodig zijn om het netwerk‑intent model "juridisch dicht" te krijgen. Ze is opgebouwd rond de zeven blokken uit de review.
+
+## 1. Schema‑laag: strikt contract
+- **Permit only what is declared:** overal `additionalProperties: false` en, waar van toepassing, `minItems`, `uniqueItems`, `format` en strikte `pattern` regels.
+- **Enumeraties en ontologie:** `vrf.zone` ∈ `{PLATFORM, TENANT, STORAGE, DMZ}`; `type` ∈ `{l2vni, l3vni, rt}`.
+- **VIP‑export:** alleen host‑routes `/32` en `/128`; subnet‑exports blokkeren. Zet dit dubbel vast: zowel in schema als in OPA.
+- **L2VNI‑consistentie:** schema vereist `l2vniBase` (integer) + `vlan` (integer). OPA valideert `l2vni == l2vniBase + vlan` en meldt de afwijking met pad en hint.
+
+## 2. EVPN/RT‑invariants
+- Geen wees‑L2VNI zonder bijbehorende L3VNI in dezelfde VRF.
+- Uniciteit: L3VNI per VRF uniek; VLAN per fabric uniek; IP‑prefixes disjunct over tenants.
+- Scope‑controle: L2VNI’s alleen geactiveerd op leaf‑pairs van het mobiliteitsdomein (klein flood‑set).
+- Ceph‑realiteit: alleen specifieke `/32` en `/128` Ceph‑public VIPs mogen gelekt worden; geen subnetten of willekeurige route‑sets naar andere tenants.
+
+## 3. IPv6 afronden
+- Dual‑stack tests voor v4/v6 combinaties en mixed allowlists.
+- Reserve‑adressen blokkeren: link‑local, multicast en ULA tenzij expliciet toegestaan.
+- VIP‑normalisatie: canonicaliseer compressie in policy zodat diff/noise verdwijnt.
+
+## 4. OPA‑policies: boodschap en structuur
+- **Stijl:** `deny[msg]` met volledig pad naar de fout en een korte fix‑hint.
+- **Packages:** scheid in kleine pakketten `schema`, `naming`, `routing`, `vni`, `exposure`.
+- **Strict toggle:** `data.policy.strict = true` als default; foutboodschap vermeldt of strict of lenient geldt.
+
+## 5. Testdekking
+- Negatieve bundels: duplicate VLAN, overlappende IPAM, ontbrekende RT‑match, L2VNI op te veel leafs, subnet‑export poging.
+- Fuzz‑cases rond grenswaarden (bijv. VLAN 199/200/201 bij base‑offset 11000).
+- Performance: `opa check`, `opa fmt`, `opa test -v` en `opa build` (Wasm artefact) in CI.
+
+## 6. CI/CD en GitOps
+- **Pre‑merge CI:** JSON Schema lint (`ajv` of `yajsv`), `opa test`, `conftest test` tegen `./examples`, `yamlfmt/prettier`, `opa fmt`, security lint (bijv. `gitleaks`).
+- **Pre‑prod:** Argo sync → post‑sync hook draait `conftest` tegen de gerenderde netwerk‑config zodat beleid ook op het eindresultaat geldt.
+- **DCIM‑feed:** NetBox levert authoritative facts (prefix, VLAN, device, rack); Git bevat de normen. OPA verifieert intent versus NetBox‑data.
+
+## 7. Documentatie en UX
+- Kies één naamstijl (kebab- of snake_case) en voer die consequent door in alle keys en voorbeelden.
+- Maak de mappenstructuur expliciet: `/schema`, `/policy`, `/tests`, `/examples`, `/pipelines`.
+- Strict mode is default; lenient is een bewuste override in `data/`.
+- Error UX: elke `deny` bevat pad, regel en een hint hoe te fixen.
+
+## 8. Golden path en mapping
+- Zie [`examples/network-intent-golden-path.yaml`](../examples/network-intent-golden-path.yaml) voor een minimaal YAML‑voorbeeld met twee tenants, één platform‑ en één storage‑VRF, plus host‑route exports.
+- Voeg aan README een sectie "Model invariants" met: `l2vni = base + vlan`, RT‑symmetrie en toegestane leaks (alleen firewall‑VRF), host‑route‑only VIP‑exports en mobiliteitsdomein‑scope voor L2VNI’s.
+- Maak een mapping tabel intent → NX‑OS CLI (VNI, NVE, SVI, RT, route‑map, BFD, eBGP) zodat operators de koppeling zien.
+
+Met deze lijst staat het contract dicht, zijn policies gestructureerd en weten operators én CI wat er verwacht wordt.

--- a/examples/network-intent-golden-path.yaml
+++ b/examples/network-intent-golden-path.yaml
@@ -1,0 +1,98 @@
+policy:
+  strict: true
+  ceph_public_vips:
+    - 172.20.0.99/32
+    - 2a02:fe0::99/128
+  mobility_leaf_pairs:
+    - leaf-a1
+    - leaf-a2
+    - leaf-b1
+    - leaf-b2
+
+fabrics:
+  - name: dc1
+    tenants:
+      - name: platform
+        vrf_zone: PLATFORM
+        l3vni: 11000
+        rt:
+          import: ["65000:11000"]
+          export: ["65000:11000"]
+        l2vni_base: 11000
+        l2vnis:
+          - name: mgmt
+            type: l2vni
+            vlan: 200
+            l2vni: 11200
+            leaf_scope: [leaf-a1, leaf-a2]
+        vip_exports:
+          - prefix: 10.0.200.10/32
+            via: firewall
+            description: "platform mgmt VIP"
+            type: host
+      - name: storage
+        vrf_zone: STORAGE
+        l3vni: 11500
+        rt:
+          import: ["65000:11500"]
+          export: ["65000:11500"]
+        l2vni_base: 11500
+        l2vnis:
+          - name: ceph-public
+            type: l2vni
+            vlan: 210
+            l2vni: 11710
+            leaf_scope: [leaf-b1, leaf-b2]
+        vip_exports:
+          - prefix: 172.20.0.99/32
+            via: firewall
+            description: "Ceph public VIP (host only)"
+            type: host
+          - prefix: 2a02:fe0::99/128
+            via: firewall
+            description: "Ceph public VIP IPv6"
+            type: host
+      - name: tenant-alpha
+        vrf_zone: TENANT
+        l3vni: 12000
+        rt:
+          import: ["65000:12000"]
+          export: ["65000:12000"]
+        l2vni_base: 12000
+        l2vnis:
+          - name: app
+            type: l2vni
+            vlan: 201
+            l2vni: 12201
+            leaf_scope: [leaf-a1, leaf-a2]
+        vip_exports:
+          - prefix: 192.0.2.10/32
+            via: firewall
+            description: "App VIP leak via firewall VRF"
+            type: host
+          - prefix: 2001:db8:1200::20/128
+            via: firewall
+            description: "App IPv6 VIP"
+            type: host
+      - name: tenant-beta
+        vrf_zone: TENANT
+        l3vni: 12100
+        rt:
+          import: ["65000:12100"]
+          export: ["65000:12100"]
+        l2vni_base: 12100
+        l2vnis:
+          - name: api
+            type: l2vni
+            vlan: 202
+            l2vni: 12302
+            leaf_scope: [leaf-b1, leaf-b2]
+        vip_exports:
+          - prefix: 198.51.100.42/32
+            via: firewall
+            description: "API VIP"
+            type: host
+          - prefix: 2001:db8:1210::42/128
+            via: firewall
+            description: "API IPv6 VIP"
+            type: host


### PR DESCRIPTION
## Summary
- document required schema, policy, and testing invariants for a closed-by-contract network intent model
- add README guardrails and link to detailed invariant guidance
- provide a golden-path YAML example covering host-only VIP exports and mobility-scoped L2VNIs

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f5a8a190832ba758a518ede92959)